### PR TITLE
Add contents:write permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,12 @@
 name: Publish library on npm registry
+
 on:
   release:
     types: [created]
+
+permissions:
+  contents: write
+
 jobs:
   publish:
     name: publish


### PR DESCRIPTION
Same deal as here: https://github.com/Cleeng/mediastore-sdk/pull/41
we need to bump the permissions because we've switched to read-only in all repos, so additional claims need to be added explicitly.