### PR TITLE
Fix switch plan popup spacing

### DIFF
--- a/src/components/SwitchPlanPopup/SwitchPlanPopupStyled.js
+++ b/src/components/SwitchPlanPopup/SwitchPlanPopupStyled.js
@@ -25,7 +25,8 @@ export const ImageWrapper = styled.div`
   justify-content: center;
   align-items: center;
 
-  margin: 0 auto 40px auto;
+  padding-top: 10px;
+  margin: 10px auto 40px auto;
 `;
 
 export const ArrowStyled = styled.span`

--- a/src/components/SwitchPlanPopup/SwitchPlanPopupStyled.js
+++ b/src/components/SwitchPlanPopup/SwitchPlanPopupStyled.js
@@ -26,7 +26,7 @@ export const ImageWrapper = styled.div`
   align-items: center;
 
   padding-top: 10px;
-  margin: 10px auto 40px auto;
+  margin: 20px auto 40px auto;
 `;
 
 export const ArrowStyled = styled.span`


### PR DESCRIPTION
- Add padding to fix the labels spacing
- Add margin to make a space between labels and the header 
<img width="392" alt="Screenshot 2022-10-11 at 08 54 47" src="https://user-images.githubusercontent.com/19149811/195017669-e0675c83-59fd-41aa-91e4-e222d7984aa3.png">
