### PR TITLE
Patch SDK version in pipelines during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,16 +18,14 @@ jobs:
           node-version: '16'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: patch sdk version
+        run: >
+          sed -i
+          "s/0.0.0-development/${{ github.event.release.tag_name }}/"
+          package.json
+
       - name: install deps
         run: npm ci
-
-      - name: Configure git user details
-        run: |
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "cleeng-devops@cleeng.com"
-
-      - name: bump version
-        run: npm version ${{ github.event.release.tag_name }}
 
       - name: compile the bundle
         run: npm run compile
@@ -36,21 +34,3 @@ jobs:
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-
-      - name: get pushbot token
-        id: pushbot
-        uses: tibdex/github-app-token@v1
-        with:
-          app_id: ${{ secrets.PUSHBOT_APP_ID }}
-          private_key: ${{ secrets.PUSHBOT_PRIVATE_KEY }}
-
-      - name: configure git token
-        env:
-          this: https://x-access-token:${{ steps.pushbot.outputs.token }}@github.com/Cleeng/
-          that: https://github.com/Cleeng/
-        run: |
-          git config --local --unset http.https://github.com/.extraheader
-          git config --global url."${{ env.this }}".insteadOf "${{ env.that }}"
-
-      - name: push updated package.json
-        run: git push --force-with-lease

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleeng/mediastore-sdk",
-  "version": "2.2.0",
+  "version": "0.0.0-development",
   "private": false,
   "main": "dist/package.js",
   "files": [


### PR DESCRIPTION
I'd like to propose this change to finally fix and vastly simplify the relase pipeline.

The idea is that during a release the pipeline will:
- replace a static string in package.json with release version
- build and push the code to npmjs.org

but it will not:
- create a commit `3.0.0` (or any other <current> version) with pacakge.json update
- push that commit to main branch


So in other words, local code will always be versioned with this fake `0.0.0-development` version, but when the sdk gets uploaded to npmjs it will have a proper version injected into package.json, just as before.

This is a quite satisfactory tradeoff for having a versioned release compared to current approach with pushing the commit back to main branch, because:
- we're obligated to push the commit safely:
  - to do so, we need to manage credentials safely, meaning we need to use a bot
  - but the dedicated bot (pushbot) does not fit here, because it has security restrictions
  - and these can't be altered for the safety of the company's internal repositories
  - meaning we'd have to create another dedicated bot just to push the code in this repo

The only disadvantage I can see is that there will be no more commits with version.
IMO that's not a real problem, because the latest 'released' commit still has a git tag pointing to it, so it wasn't needed anyway.

Please let me know what you think about this.