### PR TITLE
MSSDK-1296 fix payment details styling

### DIFF
--- a/src/components/Card/CardStyled.js
+++ b/src/components/Card/CardStyled.js
@@ -15,7 +15,7 @@ export const WrapStyled = styled.div.attrs(() => ({
   padding: 18px;
   border-radius: 12px;
 
-  margin-bottom: 39px;
+  margin-bottom: 32px;
 
   background-color: ${CardColor};
 

--- a/src/components/MyAccountError/MyAccountErrorStyled.js
+++ b/src/components/MyAccountError/MyAccountErrorStyled.js
@@ -31,6 +31,7 @@ export const SubTitleStyled = styled.div.attrs(() => ({
 export const IconStyled = styled.div.attrs(() => ({
   className: 'msd__info-box__icon'
 }))`
+  display: flex;
   margin: auto auto 10px auto;
   svg {
     max-width: 490px;

--- a/src/components/MyAccountError/MyAccountErrorStyled.js
+++ b/src/components/MyAccountError/MyAccountErrorStyled.js
@@ -32,6 +32,7 @@ export const IconStyled = styled.div.attrs(() => ({
   className: 'msd__info-box__icon'
 }))`
   display: flex;
+  justify-content: center;
   margin: auto auto 10px auto;
   svg {
     max-width: 490px;

--- a/src/components/PaymentCard/PaymentCard.js
+++ b/src/components/PaymentCard/PaymentCard.js
@@ -84,12 +84,12 @@ const PaymentCard = ({ isDataLoaded, details }) => {
                       (**** {paymentMethodSpecificParams.lastCardFourDigits})
                     </CardNumberStyled>
                   )}
-                  {paymentMethod === 'paypal' && (
-                    <HolderNameStyled>
-                      ({paymentMethodSpecificParams.holderName})
-                    </HolderNameStyled>
-                  )}
                 </CardDetailsNameWrapStyled>
+                {paymentMethod === 'paypal' && (
+                  <HolderNameStyled>
+                    ({paymentMethodSpecificParams.holderName})
+                  </HolderNameStyled>
+                )}
                 {paymentMethodSpecificParams?.cardExpirationDate && (
                   <CardExpirationStyled>
                     <CardExpirationLabel>

--- a/src/components/PaymentCard/PaymentCard.js
+++ b/src/components/PaymentCard/PaymentCard.js
@@ -87,7 +87,7 @@ const PaymentCard = ({ isDataLoaded, details }) => {
                 </CardDetailsNameWrapStyled>
                 {paymentMethod === 'paypal' && (
                   <HolderNameStyled>
-                    ({paymentMethodSpecificParams.holderName})
+                    {paymentMethodSpecificParams.holderName}
                   </HolderNameStyled>
                 )}
                 {paymentMethodSpecificParams?.cardExpirationDate && (

--- a/src/components/PaymentCard/PaymentCardStyled.js
+++ b/src/components/PaymentCard/PaymentCardStyled.js
@@ -95,7 +95,7 @@ export const CardInfoStyled = styled.div.attrs(() => ({
   justify-content: space-between;
   margin-bottom: 30px;
 
-  ${mediaFrom.smallest`
+  ${mediaFrom.medium`
     margin-bottom: 0;
   `}
 `;
@@ -131,7 +131,8 @@ export const CardInfoWrapStyled = styled.div.attrs(() => ({
   flex-direction: column;
   justify-content: space-between;
 
-  ${mediaFrom.smallest`
+  ${mediaFrom.medium`
     flex-direction: row;
+    align-items: center;
   `}
 `;

--- a/src/components/PaymentCard/PaymentCardStyled.js
+++ b/src/components/PaymentCard/PaymentCardStyled.js
@@ -4,7 +4,9 @@ import { mediaFrom } from 'styles/BreakPoints';
 
 export const CardStyled = styled.div.attrs(() => ({
   className: 'msd__payment-card'
-}))``;
+}))`
+  height: 100%;
+`;
 
 export const CardTypeStyled = styled.div.attrs(() => ({
   className: 'msd__payment-card__type'
@@ -33,8 +35,7 @@ export const HolderNameStyled = styled.div.attrs(() => ({
 }))`
   color: ${FontColor};
   font-size: 13px;
-  font-weight: 600;
-  line-height: 20px;
+  font-weight: 300;
 `;
 
 export const CardExpirationStyled = styled.div.attrs(() => ({
@@ -130,9 +131,10 @@ export const CardInfoWrapStyled = styled.div.attrs(() => ({
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  height: 100%;
 
   ${mediaFrom.medium`
     flex-direction: row;
     align-items: center;
-  `}
+  `};
 `;

--- a/src/components/PaymentMethod/PaymentMethodStyled.js
+++ b/src/components/PaymentMethod/PaymentMethodStyled.js
@@ -13,7 +13,7 @@ export const CardsWrapper = styled.div.attrs(() => ({
   display: grid;
   grid-template-columns: 1fr 1fr;
   grid-gap: 10px;
-  @media only screen and (max-width: 900px) {
+  @media only screen and (max-width: 1550px) {
     grid-template-columns: 1fr;
     > div {
       justify-self: center;


### PR DESCRIPTION
## [MSSDK-1296](https://cleeng.atlassian.net/browse/MSSDK-1296) Bound payment details in MSSDK components display error

#### Fixed payment details components display error

## Changes
- reduced margin in Card component from 39px to 32px
- centered icons in MyAccountError
- moved PayPal holderName under the method name and changed its styling
- changed breakpoint from smallest to medium in PaymentCard
- changed breakpoint from 900px to 1550px in PaymentMethod

## Screenshots
![image](https://user-images.githubusercontent.com/45321473/227500776-cf49ca29-f998-43ac-8205-16f4d5abf8fc.png)
![image](https://user-images.githubusercontent.com/45321473/227487377-c1e34cff-a581-47cd-a5d9-d1379a1d8367.png)
![image](https://user-images.githubusercontent.com/45321473/227487639-0386c961-fa79-482a-a0d0-ce4be01ef2c0.png)




[MSSDK-1296]: https://cleeng.atlassian.net/browse/MSSDK-1296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ