### PR TITLE
MSSDK-1301 bank payment methods

### DIFF
--- a/src/api/Payment/createPaymentSession.js
+++ b/src/api/Payment/createPaymentSession.js
@@ -15,12 +15,12 @@ const createPaymentSession = async (isMyAccount = false, type) => {
       method: 'POST',
       body: isMyAccount
         ? JSON.stringify({
-            returnUrl: generateReturnUrl({ isMyAccount: true })
-            // filterPaymentMethods: type
+            returnUrl: generateReturnUrl({ isMyAccount: true }),
+            filterPaymentMethods: type
           })
         : JSON.stringify({
             orderId,
-            // filterPaymentMethods: type,
+            filterPaymentMethods: type,
             returnUrl: generateReturnUrl({
               queryParams: { orderId }
             })

--- a/src/api/Payment/createPaymentSession.js
+++ b/src/api/Payment/createPaymentSession.js
@@ -3,7 +3,7 @@ import fetchWithJWT from 'util/fetchHelper';
 import getApiURL from 'util/environmentHelper';
 import generateReturnUrl from 'util/returnUrlHelper';
 
-const createPaymentSession = async isMyAccount => {
+const createPaymentSession = async (isMyAccount = false, type) => {
   const API_URL = getApiURL();
 
   const orderId = parseInt(getData('CLEENG_ORDER_ID') || '0', 10);
@@ -16,9 +16,11 @@ const createPaymentSession = async isMyAccount => {
       body: isMyAccount
         ? JSON.stringify({
             returnUrl: generateReturnUrl({ isMyAccount: true })
+            // filterPaymentMethods: type
           })
         : JSON.stringify({
             orderId,
+            // filterPaymentMethods: type,
             returnUrl: generateReturnUrl({
               queryParams: { orderId }
             })

--- a/src/components/Adyen/Adyen.js
+++ b/src/components/Adyen/Adyen.js
@@ -76,7 +76,6 @@ const Adyen = ({
   };
 
   const mountStandardDropIn = adyenCheckout => {
-    console.log('mountStandardDropIn');
     if (standardPaymentMethodsRef?.current) {
       const dropin = adyenCheckout.create('dropin', {
         onSelect,
@@ -93,7 +92,6 @@ const Adyen = ({
   };
 
   const mountBankDropIn = adyenCheckout => {
-    console.log('mountBankDropIn');
     if (bankPaymentMethodsRef?.current) {
       const dropin = adyenCheckout.create('dropin', {
         onSelect,
@@ -208,40 +206,42 @@ const Adyen = ({
 
   useEffect(() => {
     generateDropIns();
+    return () => {
+      setStandardDropInInstance(null);
+      setBankDropInInstance(null);
+    };
   }, []);
 
   useEffect(() => {
     // TODO: fix after remount
-    if (
-      bankPaymentMethodsRef &&
-      bankPaymentMethodsRef.current &&
-      standardDropInInstance
-    ) {
+    console.log('instance changed', standardDropInInstance, bankDropInInstance);
+    if (bankDropInInstance && standardDropInInstance) {
       bankPaymentMethodsRef.current.addEventListener('click', () => {
+        console.log('in on click bank', { standardDropInInstance });
         standardDropInInstance.closeActivePaymentMethod();
       });
-    }
-    if (
-      standardPaymentMethodsRef &&
-      standardPaymentMethodsRef.current &&
-      bankDropInInstance
-    ) {
       standardPaymentMethodsRef.current.addEventListener('click', () => {
+        console.log('in on click standard', { bankDropInInstance });
+
         bankDropInInstance.closeActivePaymentMethod();
       });
     }
-
     return () => {};
   }, [standardDropInInstance, bankDropInInstance]);
 
   useEffect(() => {
     if (standardDropInInstance && discount?.applied) {
+      console.log('should unmount', { standardDropInInstance });
       if (standardDropInInstance) {
         standardDropInInstance.unmount();
+        setStandardDropInInstance(null);
         getDropIn(null, 'standard');
       }
+      console.log('should unmount', { bankDropInInstance });
+
       if (bankDropInInstance) {
         bankDropInInstance.unmount();
+        setBankDropInInstance(null);
         getDropIn(null, 'bank');
       }
       setIsLoading(true);

--- a/src/components/Adyen/AdyenStyled.js
+++ b/src/components/Adyen/AdyenStyled.js
@@ -24,7 +24,7 @@ const AdyenStyled = styled.div.attrs(() => ({
     `}
   .adyen-checkout__button.adyen-checkout__button--pay {
     background: ${ConfirmColor};
-    border-radius: 30px;
+    /* border-radius: 30px; */
   }
   .adyen-checkout__payment-method__details__content {
     margin: 2px 0 20px;
@@ -83,20 +83,20 @@ const AdyenStyled = styled.div.attrs(() => ({
 
   .adyen-checkout__payment-method {
     border: 1px solid ${LineColor};
-    margin: 0;
+    margin-bottom: 10px;
   }
 
   .adyen-checkout__payment-method:not(:first-child) {
-    border-radius: 0;
+    /* border-radius: 0; */
   }
 
   .adyen-checkout__payment-method:first-child {
-    border-radius: 12px 12px 0 0;
+    /* border-radius: 12px 12px 0 0; */
   }
 
   .adyen-checkout__payment-method:last-child {
-    border-radius: ${({ isAdditionalPayment }) =>
-      isAdditionalPayment ? 'none' : '12px'};
+    /* border-radius: ${({ isAdditionalPayment }) =>
+      isAdditionalPayment ? 'none' : '12px'}; */
   }
 
   .adyen-checkout__payment-method--selected {
@@ -106,6 +106,16 @@ const AdyenStyled = styled.div.attrs(() => ({
   .adyen-checkout__payment-method__radio--selected {
     background-color: ${ConfirmColor};
   }
+
+  .adyen__bank-copy {
+    font-size: 11px;
+    margin: 10px 20px 20px 20px;
+    line-height: 17px;
+    font-weight: 400;
+    color: #7b849d;
+    text-align: center;
+  }
+
   ${({ isAdditionalPayment }) =>
     isAdditionalPayment &&
     css`

--- a/src/components/Adyen/AdyenStyled.js
+++ b/src/components/Adyen/AdyenStyled.js
@@ -84,6 +84,8 @@ const AdyenStyled = styled.div.attrs(() => ({
   .adyen-checkout__payment-method {
     border: 1px solid ${LineColor};
     margin-bottom: 10px;
+    border-radius: 12px;
+    overflow: hidden;
   }
 
   .adyen-checkout__payment-method:not(:first-child) {

--- a/src/components/Payment/DropInSection/DropInSection.js
+++ b/src/components/Payment/DropInSection/DropInSection.js
@@ -15,7 +15,6 @@ const DropInSection = ({
   selectPaymentMethod,
   title,
   logo,
-  isCardAvailable,
   isLoading
 }) => {
   const { selectedPaymentMethod } = useSelector(state => state.paymentMethods);
@@ -29,7 +28,6 @@ const DropInSection = ({
   return (
     <WrapperStyled
       isSelected={isSelected}
-      isCardAvailable={isCardAvailable}
       onClick={() => !fadeOutSection && selectPaymentMethod('paypal')}
       fadeOutSection={fadeOutSection}
     >
@@ -55,7 +53,6 @@ DropInSection.propTypes = {
   title: PropTypes.string.isRequired,
   logo: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
-  isCardAvailable: PropTypes.bool.isRequired,
   isLoading: PropTypes.bool.isRequired
 };
 

--- a/src/components/Payment/DropInSection/DropInSectionStyled.js
+++ b/src/components/Payment/DropInSection/DropInSectionStyled.js
@@ -12,9 +12,8 @@ export const WrapperStyled = styled.div.attrs(() => ({
   display: flex;
   flex-direction: column;
   justify-content: center;
-  border-radius: ${({ isCardAvailable }) =>
-    isCardAvailable ? '0 0 12px 12px' : '12px;'};
   background-color: ${colors.White};
+  border-radius: 12px;
   border: 1px solid
     ${({ isSelected }) => (isSelected ? ConfirmColor : '#D3DBE6')};
   cursor: ${({ fadeOutSection }) => (fadeOutSection ? 'default' : 'pointer')};

--- a/src/components/Payment/Payment.js
+++ b/src/components/Payment/Payment.js
@@ -47,7 +47,8 @@ const Payment = ({ t, onPaymentComplete }) => {
     : null;
   const [isLoading, setIsLoading] = useState(false);
   const [generalError, setGeneralError] = useState('');
-  const [dropInInstance, setDropInInstance] = useState(null);
+  const [standardDropInInstance, setStandardDropInInstance] = useState(null);
+  const [bankDropInInstance, setBankDropInInstance] = useState(null);
   const [adyenKey, setAdyenKey] = useState(false);
   const [isActionHandlingProcessing, setIsActionHandlingProcessing] = useState(
     false
@@ -173,7 +174,8 @@ const Payment = ({ t, onPaymentComplete }) => {
       );
       setIsLoading(false);
       // force Adyen remount
-      setDropInInstance(null);
+      setStandardDropInInstance(null);
+      setBankDropInInstance(null);
       setAdyenKey(key => !key);
       return;
     }
@@ -192,8 +194,12 @@ const Payment = ({ t, onPaymentComplete }) => {
     onPaymentComplete();
   };
 
-  const getDropIn = drop => {
-    setDropInInstance(drop);
+  const getDropIn = (drop, type) => {
+    if (type === 'bank') {
+      setBankDropInInstance(drop);
+    } else {
+      setStandardDropInInstance(drop);
+    }
   };
 
   // Payment without payment details
@@ -219,7 +225,7 @@ const Payment = ({ t, onPaymentComplete }) => {
   const shouldShowPayPal = shouldShowGatewayComponent('paypal', paymentMethods);
 
   const showPayPalWhenAdyenIsReady = () =>
-    shouldShowAdyen ? !!dropInInstance : true;
+    shouldShowAdyen ? !!standardDropInInstance || !!bankDropInInstance : true;
 
   if (!paymentMethods.length) {
     return (

--- a/src/components/Payment/Payment.js
+++ b/src/components/Payment/Payment.js
@@ -179,6 +179,9 @@ const Payment = ({ t, onPaymentComplete }) => {
       setAdyenKey(key => !key);
       return;
     }
+    useEffect(() => {
+      console.log({ adyenKey });
+    }, [adyenKey]);
 
     const { action, payment } = responseData;
     if (action) {
@@ -285,7 +288,6 @@ const Payment = ({ t, onPaymentComplete }) => {
           showPayPalWhenAdyenIsReady() &&
           !isActionHandlingProcessing && (
             <DropInSection
-              isCardAvailable={shouldShowAdyen}
               selectPaymentMethod={selectPaymentMethodHandler}
               title="PayPal"
               logo="paypal"

--- a/src/components/Payment/Payment.js
+++ b/src/components/Payment/Payment.js
@@ -179,10 +179,6 @@ const Payment = ({ t, onPaymentComplete }) => {
       setAdyenKey(key => !key);
       return;
     }
-    useEffect(() => {
-      console.log({ adyenKey });
-    }, [adyenKey]);
-
     const { action, payment } = responseData;
     if (action) {
       if (action.type !== 'redirect') {

--- a/src/components/UpdatePaymentDetailsPopup/UpdatePaymentDetailsPopup.js
+++ b/src/components/UpdatePaymentDetailsPopup/UpdatePaymentDetailsPopup.js
@@ -360,7 +360,6 @@ const UpdatePaymentDetailsPopup = () => {
             showPayPalWhenAdyenIsReady() &&
             !isActionHandlingProcessing && (
               <DropInSection
-                isCardAvailable={shouldShowAdyen}
                 selectPaymentMethod={selectPaymentMethodHandler}
                 title="PayPal"
                 logo="paypal"


### PR DESCRIPTION
- create and embed two drop-ins: one for standard payment methods and one for bank once
- fix 'drop in recreate' logic
- adjust styling
<img width="451" alt="Screen Shot 2023-03-27 at 8 11 34 AM" src="https://user-images.githubusercontent.com/41182484/227855726-1616785f-8e4d-4c0a-a195-9d526ef1a41a.png">
- add copy for bank payment methods
<img width="448" alt="Screen Shot 2023-03-27 at 8 12 55 AM" src="https://user-images.githubusercontent.com/41182484/227855671-b94dd9a7-7079-4cb0-9790-7f6e698a1606.png">
