### PR TITLE
MSSDK-1302-dynamic-trial-label

### DIFF
--- a/src/components/OfferCheckoutCard/OfferCheckoutCard.js
+++ b/src/components/OfferCheckoutCard/OfferCheckoutCard.js
@@ -38,6 +38,7 @@ const OfferCheckoutCard = ({ isDataLoaded, t }) => {
   } = useSelector(state => state.order.order);
   const offerType = offerId?.charAt(0);
   const currencySymbol = currencyFormat[currency];
+
   const generateTrialDescription = () => {
     const grossPrice = formatNumber(offerPrice + taxRate * offerPrice);
     const taxCopy = country === 'US' ? 'Tax' : 'VAT';
@@ -128,6 +129,26 @@ const OfferCheckoutCard = ({ isDataLoaded, t }) => {
     return '';
   };
 
+  const generateTrialBadgeDescription = () => {
+    if (freeDays) {
+      return t('trial-badge-days', `${freeDays} days free trial`, { freeDays });
+    }
+
+    if (freePeriods === 1) {
+      return t(
+        `trial-badge.period-${period}`,
+        `1 ${period} free trial`,
+        period
+      );
+    }
+
+    return t(
+      `trial-badge.periods-${period}`,
+      `${freePeriods} ${period}s free trial`,
+      { freePeriods, period }
+    );
+  };
+
   return (
     <WrapperStyled>
       <SkeletonWrapper showChildren={isDataLoaded} width={50} height={50}>
@@ -154,7 +175,9 @@ const OfferCheckoutCard = ({ isDataLoaded, t }) => {
       <PriceWrapperStyled>
         <SkeletonWrapper showChildren={isDataLoaded} width={80} height={30}>
           {isTrialAvailable && (
-            <TrialBadgeStyled>{t('trial period')}</TrialBadgeStyled>
+            <TrialBadgeStyled>
+              {generateTrialBadgeDescription()}
+            </TrialBadgeStyled>
           )}
           <Price
             currency={currencyFormat[currency]}

--- a/src/components/OfferCheckoutCard/OfferCheckoutCard.js
+++ b/src/components/OfferCheckoutCard/OfferCheckoutCard.js
@@ -138,18 +138,20 @@ const OfferCheckoutCard = ({ isDataLoaded, t }) => {
 
   const generateTrialBadgeDescription = () => {
     if (freeDays) {
-      return t('trial-badge-days', `${freeDays} days free trial`, { freeDays });
+      return t('trial-badge-days', `{{freeDays}} days free trial`, {
+        freeDays
+      });
     }
 
     if (freePeriods === 1) {
-      return t(`trial-badge.period-${period}`, `1 ${period} free trial`, {
+      return t(`trial-badge.period-${period}`, `1 {{period}} free trial`, {
         period
       });
     }
 
     return t(
       `trial-badge.periods-${period}`,
-      `${freePeriods} ${period}s free trial`,
+      `{{freePeriods}} {{period}}s free trial`,
       { freePeriods, period }
     );
   };

--- a/src/components/OfferCheckoutCard/OfferCheckoutCard.js
+++ b/src/components/OfferCheckoutCard/OfferCheckoutCard.js
@@ -107,7 +107,7 @@ const OfferCheckoutCard = ({ isDataLoaded, t }) => {
     return generateTrialDescription();
   };
 
-  const generateDescription = () => {
+  const renderDescription = () => {
     if (offerType === 'S') {
       return generateSubscriptionDescription();
     }
@@ -136,7 +136,7 @@ const OfferCheckoutCard = ({ isDataLoaded, t }) => {
     return '';
   };
 
-  const generateTrialBadgeDescription = () => {
+  const renderTrialBadgeDescription = () => {
     if (freeDays) {
       return t('trial-badge-days', `{{freeDays}} days free trial`, {
         freeDays
@@ -175,16 +175,14 @@ const OfferCheckoutCard = ({ isDataLoaded, t }) => {
           margin="0 0 10px 10px"
         >
           <DescriptionStyled
-            dangerouslySetInnerHTML={{ __html: generateDescription() }}
+            dangerouslySetInnerHTML={{ __html: renderDescription() }}
           />
         </SkeletonWrapper>
       </InnerWrapper>
       <PriceWrapperStyled>
         <SkeletonWrapper showChildren={isDataLoaded} width={80} height={30}>
           {isTrialAvailable && (
-            <TrialBadgeStyled>
-              {generateTrialBadgeDescription()}
-            </TrialBadgeStyled>
+            <TrialBadgeStyled>{renderTrialBadgeDescription()}</TrialBadgeStyled>
           )}
           <Price
             currency={currencyFormat[currency]}

--- a/src/components/OfferCheckoutCard/OfferCheckoutCard.js
+++ b/src/components/OfferCheckoutCard/OfferCheckoutCard.js
@@ -135,11 +135,9 @@ const OfferCheckoutCard = ({ isDataLoaded, t }) => {
     }
 
     if (freePeriods === 1) {
-      return t(
-        `trial-badge.period-${period}`,
-        `1 ${period} free trial`,
+      return t(`trial-badge.period-${period}`, `1 ${period} free trial`, {
         period
-      );
+      });
     }
 
     return t(

--- a/src/components/OfferCheckoutCard/OfferCheckoutCardStyled.js
+++ b/src/components/OfferCheckoutCard/OfferCheckoutCardStyled.js
@@ -65,7 +65,8 @@ export const PriceWrapperStyled = styled.div.attrs(() => ({
 export const TrialBadgeStyled = styled.div.attrs(() => ({
   className: 'msd__checkout-card-price__badge'
 }))`
-  width: 80px;
+  min-width: 80px;
+  max-width: 110px;
   padding: 4px 8px;
   margin-bottom: 4px;
   background-color: ${White};

--- a/src/components/OfferCheckoutCard/OfferCheckoutCardStyled.js
+++ b/src/components/OfferCheckoutCard/OfferCheckoutCardStyled.js
@@ -65,8 +65,7 @@ export const PriceWrapperStyled = styled.div.attrs(() => ({
 export const TrialBadgeStyled = styled.div.attrs(() => ({
   className: 'msd__checkout-card-price__badge'
 }))`
-  min-width: 80px;
-  max-width: 110px;
+  width: 80px;
   padding: 4px 8px;
   margin-bottom: 4px;
   background-color: ${White};

--- a/src/translations/en/translations.json
+++ b/src/translations/en/translations.json
@@ -406,5 +406,10 @@
   "resume-subscription-popup.confirm-button-text": "Resume subscription",
   "resume-subscription-popup.back-button-text": "Continue Pause",
   "resume-subscription-popup.success-header": "Thank you!",
-  "resume-subscription-popup.success-text": "You have successfully resumed your plan <strong>{{ planName }}.</strong>"
+  "resume-subscription-popup.success-text": "You have successfully resumed your plan <strong>{{ planName }}.</strong>",
+  "trial-badge-days": "{{freeDays}} days free trial",
+  "trial-badge.period-week": "1 week free trial",
+  "trial-badge.period-month": "1 month free trial",
+  "trial-badge.periods-week": "{{freePeriods}} weeks free trial",
+  "trial-badge.periods-month": "{{freePeriods}} months free trial"
 }


### PR DESCRIPTION

### [MSSDK-1302](https://cleeng.atlassian.net/jira/software/c/projects/MSSDK/boards/88?modal=detail&selectedIssue=MSSDK-1302)

**Dynamic trial label on the checkout page**

#### Changes

- added generateTrialBadgeDescription() function to handle days and periods variants with dynamic translation
- updated translations.json file with keys and values accordingly
- changed label's min- and max-width values

#### Snapshots

<img width="885" alt="days-eng" src="https://user-images.githubusercontent.com/30701167/229704171-531ec528-f053-49f6-9452-7b01814ddcbf.png">

<img width="886" alt="months-eng" src="https://user-images.githubusercontent.com/30701167/229704668-ded54129-b6dc-4a82-a394-21348d762785.png">

<img width="899" alt="7-days-ger" src="https://user-images.githubusercontent.com/30701167/229704495-e4824fee-419f-41e7-97de-91b684f74d3d.png">




[MSSDK-1302]: https://cleeng.atlassian.net/browse/MSSDK-1302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ