### PR TITLE
remove node_modules CSS imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # MediaStore SDK
 
+## **Warning: breaking changes in version 4.0**
+
+See the [imports](#cssImports) section of this file for more information.
+
 This is the Cleeng official component library to be used with React.js.
 
 MediaStore SDK Library consists of components that will allow you to build a seamless checkout process, help visitors become subscribers, and then allow them to manage their subscriptions.
@@ -67,12 +71,12 @@ Setting the environment is required for all components. The environment is one o
 - `sandbox` (default)
 - `production`
 
-#### Import the required CSS
+#### Import the required CSS<a name="cssImports"></a>
 
-We removed CSS imports from third-party libraries in version x.y (//TODO: add version) to improve compatibility with Next.js (which, as of version 13 doesn't allow CSS imports from the `node_modules` directory). You'll have to import them manually in your app:
+**We removed CSS imports from third-party libraries in version 4.0** to improve compatibility with Next.js (which, [somewhat controversially](https://github.com/vercel/next.js/discussions/27953), doesn't currently allow CSS imports from the `node_modules` directory). You'll have to import them manually in your app:
 
 ```javascript
-// _app.js for Next.js projects, your main App component for other use cases
+// import the following stylesheets in _app.js for Next.js projects, or your main App component for other use cases
 
 import "@adyen/adyen-web/dist/adyen.css";
 import "react-loading-skeleton/dist/skeleton.css";

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you have the package downloaded locally and you want to begin to use it, you 
 
 Config functions save data to local storage (as `CLEENG_*` items). These data are required to make components work. <b>You need to call these functions, before MSSDK components mount, usually only once.</b>
 
-##### Setting environment
+#### Setting environment
 
 ```javascript
 import { Config } from "@cleeng/mediastore-sdk";
@@ -66,6 +66,17 @@ Setting the environment is required for all components. The environment is one o
 
 - `sandbox` (default)
 - `production`
+
+#### Import the required CSS
+
+We removed CSS imports from third-party libraries in version x.y (//TODO: add version) to improve compatibility with Next.js (which, as of version 13 doesn't allow CSS imports from the `node_modules` directory). You'll have to import them manually in your app:
+
+```javascript
+// _app.js for Next.js projects, your main App component for other use cases
+
+import "@adyen/adyen-web/dist/adyen.css";
+import "react-loading-skeleton/dist/skeleton.css";
+```
 
 **Each component needs to be wrapper into Provider, as in the example below.**
 

--- a/src/components/Adyen/Adyen.js
+++ b/src/components/Adyen/Adyen.js
@@ -7,7 +7,6 @@ import createPaymentSession from 'api/Payment/createPaymentSession';
 import useScript from 'util/useScriptHook';
 import { useSelector } from 'react-redux';
 import AdyenStyled from './AdyenStyled';
-import '@adyen/adyen-web/dist/adyen.css';
 import eventDispatcher, { MSSDK_ADYEN_ERROR } from '../../util/eventDispatcher';
 import Loader from '../Loader';
 import {

--- a/src/components/SkeletonWrapper/SkeletonWrapper.js
+++ b/src/components/SkeletonWrapper/SkeletonWrapper.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import Skeleton, { SkeletonTheme } from 'react-loading-skeleton';
 import { LoaderColor } from 'styles/variables';
-import 'react-loading-skeleton/dist/skeleton.css';
 
 export const SkeletonWrapperStyled = styled.div.attrs(() => ({
   className: 'msd__skeleton'


### PR DESCRIPTION
### Description 

Next.js doesn't allow third-party CSS imports from `node_modules` (as reported in #197) and throws the [css-npm](https://nextjs.org/docs/messages/css-npm) error while importing our library.

### Updates

Removed the imports in the offending components:
- `Adyen.js`
- `SkeletonWrapper.js`

And updated the README to reflect the changes required by this.