### PR TITLE
MSSDK-1314 - fix tax annotation display

### DIFF
--- a/src/components/CheckoutPriceBox/CheckoutPriceBox.js
+++ b/src/components/CheckoutPriceBox/CheckoutPriceBox.js
@@ -43,6 +43,7 @@ const CheckoutPriceBox = ({ t }) => {
             <span>{country === 'US' ? t('excl. Tax') : t('excl. VAT')}</span>
           </StyledOfferPrice>
         </StyledPriceWrapper>
+
         {isCouponApplied && (
           <StyledPriceWrapper>
             <StyledLabel>{t('Coupon Discount')}</StyledLabel>
@@ -52,6 +53,7 @@ const CheckoutPriceBox = ({ t }) => {
             </StyledOfferPrice>
           </StyledPriceWrapper>
         )}
+
         <StyledPriceWrapper>
           <StyledLabel>
             {country === 'US' ? t('Applicable Tax') : t('Applicable VAT')}
@@ -71,6 +73,7 @@ const CheckoutPriceBox = ({ t }) => {
             )}
           </StyledOfferPrice>
         </StyledPriceWrapper>
+
         {customerServiceFee !== 0 && (
           <StyledPriceWrapper>
             <StyledLabel>{t('Service Fee')}</StyledLabel>
@@ -79,6 +82,7 @@ const CheckoutPriceBox = ({ t }) => {
             </StyledOfferPrice>
           </StyledPriceWrapper>
         )}
+
         {paymentMethodFee !== 0 && (
           <StyledPriceWrapper>
             <StyledLabel>{t('Payment Method Fee')}</StyledLabel>
@@ -87,6 +91,7 @@ const CheckoutPriceBox = ({ t }) => {
             </StyledOfferPrice>
           </StyledPriceWrapper>
         )}
+
         <StyledPriceWrapper>
           <StyledTotalLabel>{t('Total')}</StyledTotalLabel>
           <StyledTotalOfferPrice>

--- a/src/components/CheckoutPriceBox/CheckoutPriceBox.js
+++ b/src/components/CheckoutPriceBox/CheckoutPriceBox.js
@@ -43,7 +43,6 @@ const CheckoutPriceBox = ({ t }) => {
             <span>{country === 'US' ? t('excl. Tax') : t('excl. VAT')}</span>
           </StyledOfferPrice>
         </StyledPriceWrapper>
-
         {isCouponApplied && (
           <StyledPriceWrapper>
             <StyledLabel>{t('Coupon Discount')}</StyledLabel>
@@ -53,31 +52,25 @@ const CheckoutPriceBox = ({ t }) => {
             </StyledOfferPrice>
           </StyledPriceWrapper>
         )}
-        {(taxValue !== 0 || taxRate !== 0) && (
-          <StyledPriceWrapper>
-            <StyledLabel>
-              {country === 'US' ? t('Applicable Tax') : t('Applicable VAT')}
-            </StyledLabel>
-            <StyledOfferPrice>
-              {taxValue ? (
-                `${currencyFormat[currency]}${formatNumber(taxValue)}`
-              ) : (
-                <></>
-              )}
-              {!taxValue && taxRate && isCouponApplied && (
-                <p style={{ textDecoration: 'line-through' }}>
-                  {currencyFormat[currency]}{' '}
-                  {calculateTaxValueForFreeOffer(
-                    offerPrice,
-                    taxRate,
-                    customerPriceInclTax
-                  )}
-                </p>
-              )}
-            </StyledOfferPrice>
-          </StyledPriceWrapper>
-        )}
-
+        <StyledPriceWrapper>
+          <StyledLabel>
+            {country === 'US' ? t('Applicable Tax') : t('Applicable VAT')}
+          </StyledLabel>
+          <StyledOfferPrice>
+            {!taxValue && isCouponApplied ? (
+              <p style={{ textDecoration: 'line-through' }}>
+                {currencyFormat[currency]}{' '}
+                {calculateTaxValueForFreeOffer(
+                  offerPrice,
+                  taxRate,
+                  customerPriceInclTax
+                )}
+              </p>
+            ) : (
+              `${currencyFormat[currency]}${formatNumber(taxValue)}`
+            )}
+          </StyledOfferPrice>
+        </StyledPriceWrapper>
         {customerServiceFee !== 0 && (
           <StyledPriceWrapper>
             <StyledLabel>{t('Service Fee')}</StyledLabel>
@@ -86,7 +79,6 @@ const CheckoutPriceBox = ({ t }) => {
             </StyledOfferPrice>
           </StyledPriceWrapper>
         )}
-
         {paymentMethodFee !== 0 && (
           <StyledPriceWrapper>
             <StyledLabel>{t('Payment Method Fee')}</StyledLabel>
@@ -95,7 +87,6 @@ const CheckoutPriceBox = ({ t }) => {
             </StyledOfferPrice>
           </StyledPriceWrapper>
         )}
-
         <StyledPriceWrapper>
           <StyledTotalLabel>{t('Total')}</StyledTotalLabel>
           <StyledTotalOfferPrice>


### PR DESCRIPTION
### Description 
Tax annotation in  is now visible in all cases, even if its value shows 0.  In case of free offers, tax segment is always struck through. 

Previously, there was no tax row displayed when its value was equal to 0, what might have led to a confusion for non-EU customers when they were presented with inconsistent _incl._ - _excl._  tax information in `Checkout`

### Updates
Conditional rendering for tax row has been removed leaving only a ternary operator determining if the offer is free or not.

### Screenshots

<img width="836" alt="image" src="https://user-images.githubusercontent.com/30701167/231681811-ec7b24c7-bed7-4118-9a34-d3e8ef8629ec.png">
