### PR TITLE
remove customer-identifying data on logout

### DIFF
--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -89,6 +89,10 @@ class Auth {
     removeData('CLEENG_MYACCOUNT_PP_SUCCESS');
     removeData('CLEENG_MYACCOUNT_PP_CANCEL');
     removeData('CLEENG_MYACCOUNT_PP_ERROR');
+    removeData('CLEENG_CUSTOMER_EMAIL');
+    removeData('CLEENG_CUSTOMER_ID');
+    removeData('CLEENG_ENVIRONMENT');
+    removeData('CLEENG_PUBLISHER_ID');
 
     callback();
   }


### PR DESCRIPTION
### Description 

There has been a client report of user data leaking between sessions

### Updates

Remove more data from localStorage & store on user logout:
- customer email, 
- customer ID,
-  environment, 
-  publisher ID