### PR TITLE
update styling for smaller displays in the Capture component

### DIFF
--- a/src/components/Capture/CaptureForm/CaptureFormStyled.js
+++ b/src/components/Capture/CaptureForm/CaptureFormStyled.js
@@ -1,11 +1,16 @@
 /* eslint-disable import/prefer-default-export */
 import styled, { css } from 'styled-components';
+import { media } from 'styles/BreakPoints';
 import { ErrorColor } from 'styles/variables';
 
 export const CaptureFormStyled = styled.form``;
 
 export const CaptureRowStyled = styled.div`
   display: flex;
+
+  ${media.small`
+    display: block;
+  `}
 `;
 
 export const CaptureGroupStyled = styled.div``;

--- a/src/components/Capture/CaptureStyled.js
+++ b/src/components/Capture/CaptureStyled.js
@@ -23,6 +23,10 @@ export const CaptureContentStyled = styled.div`
 
   text-align: center;
 
+  ${media.medium`
+    padding-inline: 5%;
+  `}
+
   ${media.small`
     width: 80%;
   `}


### PR DESCRIPTION
### Description 

The capture component's inputs were getting squished on smaller displays

### Updates

Modified styling for the component:
- reduced content padding to 5% on displays < 1024px wide,
- flipped the input wrapper back to `display: block` on displays < 768px wide so input siblings drop down

### Screenshots 
Before:
<img width="318" alt="Capture component with squished inputs" src="https://user-images.githubusercontent.com/10454169/232814465-05227591-92c8-4f60-8748-f4c6585c2121.png">
After: 
<img width="321" alt="Capture component with the inputs rendered correctly" src="https://user-images.githubusercontent.com/10454169/232815055-94d4bccd-ca79-450b-a7b2-b6ffa7b97494.png">

