### PR TITLE
[MSSDK-1385] Add right-to-left support in mediastore-sdk

### DIFF
--- a/src/components/Adyen/AdyenStyled.js
+++ b/src/components/Adyen/AdyenStyled.js
@@ -1,5 +1,4 @@
 import styled, { css } from 'styled-components';
-import { isRTL } from 'styles/RTLHelper';
 import {
   FontColor,
   ConfirmColor,
@@ -131,12 +130,8 @@ const AdyenStyled = styled.div.attrs(() => ({
     css`
       .adyen-checkout__payment-method--standalone {
         .adyen-checkout__payment-method__header {
-          padding: 12px 16px 12px 44px;
-
-          ${isRTL() &&
-            css`
-              padding: 12px 44px 12px 16px;
-            `}
+          padding-block: 12px;
+          padding-inline: 44px 16px;
         }
 
         .adyen-checkout__payment-method__radio {

--- a/src/components/Adyen/AdyenStyled.js
+++ b/src/components/Adyen/AdyenStyled.js
@@ -133,7 +133,7 @@ const AdyenStyled = styled.div.attrs(() => ({
         .adyen-checkout__payment-method__header {
           padding: 12px 16px 12px 44px;
 
-          ${isRTL &&
+          ${isRTL() &&
             css`
               padding: 12px 44px 12px 16px;
             `}

--- a/src/components/Adyen/AdyenStyled.js
+++ b/src/components/Adyen/AdyenStyled.js
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import { isRTL } from 'styles/RTLHelper';
 import {
   FontColor,
   ConfirmColor,
@@ -131,6 +132,11 @@ const AdyenStyled = styled.div.attrs(() => ({
       .adyen-checkout__payment-method--standalone {
         .adyen-checkout__payment-method__header {
           padding: 12px 16px 12px 44px;
+
+          ${isRTL &&
+            css`
+              padding: 12px 44px 12px 16px;
+            `}
         }
 
         .adyen-checkout__payment-method__radio {

--- a/src/components/Checkbox/CheckboxStyled.js
+++ b/src/components/Checkbox/CheckboxStyled.js
@@ -1,5 +1,4 @@
 import styled, { css } from 'styled-components';
-import { isRTL } from 'styles/RTLHelper';
 import {
   FontColor,
   ErrorColor,
@@ -40,7 +39,7 @@ export const ConsentDefinitionStyled = styled.div.attrs(props => ({
   }`
 }))`
   position: relative;
-  padding-left: 10px;
+  padding-inline-start: 10px;
   margin-top: 0;
 
   font-weight: 400;
@@ -58,12 +57,6 @@ export const ConsentDefinitionStyled = styled.div.attrs(props => ({
     props.checked &&
     css`
       opacity: 1;
-    `}
-
-  ${isRTL() &&
-    css`
-      padding-left: 0;
-      padding-right: 10px;
     `}
 `;
 

--- a/src/components/Checkbox/CheckboxStyled.js
+++ b/src/components/Checkbox/CheckboxStyled.js
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import { isRTL } from 'styles/RTLHelper';
 import {
   FontColor,
   ErrorColor,
@@ -57,6 +58,12 @@ export const ConsentDefinitionStyled = styled.div.attrs(props => ({
     props.checked &&
     css`
       opacity: 1;
+    `}
+
+  ${isRTL() &&
+    css`
+      padding-left: 0;
+      padding-right: 10px;
     `}
 `;
 

--- a/src/components/CouponInput/CouponInputStyled.js
+++ b/src/components/CouponInput/CouponInputStyled.js
@@ -1,6 +1,7 @@
 import styled, { css } from 'styled-components';
 import * as Colors from 'styles/variables';
 import { media } from 'styles/BreakPoints';
+import { isRTL } from 'styles/RTLHelper';
 import { MESSAGE_TYPE_SUCCESS } from 'components/Input/InputConstants';
 
 export const InputComponentStyled = styled.div.attrs(() => ({
@@ -84,6 +85,12 @@ export const InputElementStyled = styled.input.attrs(() => ({
         `}
     `}
 
+  ${isRTL() &&
+    css`
+      right: 37px;
+      left: unset;
+    `}
+
   ${props =>
     props.readOnly &&
     css`
@@ -109,6 +116,12 @@ export const CloseButtonStyled = styled.button.attrs(() => ({
   justify-content: center;
   align-items: center;
   cursor: pointer;
+
+  ${isRTL() &&
+    css`
+      right: 7px;
+      left: unset;
+    `}
 
   svg {
     transform: scale(0.3);

--- a/src/components/CouponInput/CouponInputStyled.js
+++ b/src/components/CouponInput/CouponInputStyled.js
@@ -1,7 +1,6 @@
 import styled, { css } from 'styled-components';
 import * as Colors from 'styles/variables';
 import { media } from 'styles/BreakPoints';
-import { isRTL } from 'styles/RTLHelper';
 import { MESSAGE_TYPE_SUCCESS } from 'components/Input/InputConstants';
 
 export const InputComponentStyled = styled.div.attrs(() => ({
@@ -71,7 +70,7 @@ export const InputElementStyled = styled.input.attrs(() => ({
     css`
       width: 198px;
       max-width: 198px;
-      left: 37px;
+      inset-inline-start: 37px;
       padding-right: 25px;
       ${media.small`
         width: 100%;
@@ -83,12 +82,6 @@ export const InputElementStyled = styled.input.attrs(() => ({
           width: 100%;
           max-width: 100%;
         `}
-    `}
-
-  ${isRTL() &&
-    css`
-      right: 37px;
-      left: unset;
     `}
 
   ${props =>
@@ -105,7 +98,7 @@ export const CloseButtonStyled = styled.button.attrs(() => ({
   height: 22px;
   width: 22px;
   top: 50%;
-  left: 7px;
+  inset-inline-start: 7px;
   transform: translate(0, -50%);
   background-color: ${Colors.PrimaryColor};
   opacity: 0;
@@ -116,12 +109,6 @@ export const CloseButtonStyled = styled.button.attrs(() => ({
   justify-content: center;
   align-items: center;
   cursor: pointer;
-
-  ${isRTL() &&
-    css`
-      right: 7px;
-      left: unset;
-    `}
 
   svg {
     transform: scale(0.3);

--- a/src/components/MyAccountInput/MyAccountInputStyled.js
+++ b/src/components/MyAccountInput/MyAccountInputStyled.js
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import { isRTL } from 'styles/RTLHelper';
 import {
   FontColor,
   BackgroundColor,
@@ -38,6 +39,11 @@ export const InputElementStyled = styled.input.attrs(() => ({
   border-radius: 4px;
   font-size: 13px;
   line-height: 13px;
+
+  ${isRTL() &&
+    css`
+      text-align: right;
+    `}
 
   &:focus,
   &:active {

--- a/src/components/MyAccountMenu/MyAccountMenuStyled.js
+++ b/src/components/MyAccountMenu/MyAccountMenuStyled.js
@@ -1,5 +1,6 @@
 import styled, { css } from 'styled-components';
 import { mediaFrom } from 'styles/BreakPoints';
+import { isRTL } from 'styles/RTLHelper';
 import { MyAccountTextGray, FontColor, ConfirmColor } from 'styles/variables';
 
 export const WrapStyled = styled.nav`
@@ -66,6 +67,7 @@ export const ItemIconWrapStyled = styled.div.attrs(() => ({
     display: flex;
     border: 0;
     height: 50px;
+    width: 30px;
   `}
 `;
 
@@ -91,11 +93,16 @@ export const ItemLabelStyled = styled.div.attrs(() => ({
     transform: scaleX(0);
     transition: transform 250ms ease-in-out;
     transform-origin: 0% 50%;
+
+    ${isRTL() &&
+      css`
+        transform-origin: 100% 50%;
+      `}
   }
 
   ${mediaFrom.small`
-    margin: auto auto auto 20px;
-   font-size: 15px;
+    margin: auto 20px auto 20px;
+    font-size: 15px;
   `}
 `;
 

--- a/src/components/OfferCard/OfferCard.js
+++ b/src/components/OfferCard/OfferCard.js
@@ -173,14 +173,14 @@ const OfferCard = ({
           <SkeletonWrapper
             showChildren={isDataLoaded}
             width={200}
-            margin="0 0 10px 10px"
+            margin="0 10px 10px 10px"
           >
             <TitleStyled>{t(`offer-title-${offerId}`, title)}</TitleStyled>
           </SkeletonWrapper>
           <SkeletonWrapper
             showChildren={isDataLoaded}
             width={300}
-            margin="0 0 10px 10px"
+            margin="0 10px 10px 10px"
           >
             <DescriptionStyled
               dangerouslySetInnerHTML={{ __html: description }}

--- a/src/components/OfferCard/OfferCardStyled.js
+++ b/src/components/OfferCard/OfferCardStyled.js
@@ -1,6 +1,5 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { mediaFrom } from 'styles/BreakPoints';
-import { isRTL } from 'styles/RTLHelper';
 import {
   BoldFont,
   MediumFont,
@@ -28,11 +27,11 @@ export const InnerWrapper = styled.div.attrs(() => ({
 }))`
   max-width: 50%;
   color: ${FontColor};
-  margin-right: 15px;
+  margin-inline-end: 15px;
 
   ${mediaFrom.small`
     max-width: none;
-    margin-right: 20px;
+    margin-inline-end: 20px;
   `}
 `;
 
@@ -63,12 +62,7 @@ export const PriceWrapperStyled = styled.div.attrs(() => ({
 }))`
   display: flex;
   flex-direction: column;
-  margin: auto 0 auto auto;
-
-  ${isRTL() &&
-    css`
-      margin: auto auto auto 0;
-    `}
+  margin-inline: auto 0;
 `;
 
 export const TrialBadgeStyled = styled.div.attrs(() => ({
@@ -109,13 +103,8 @@ export const BoxTextStyled = styled.p.attrs(() => ({
 }))`
   font-size: ${TinyFont};
   color: ${FontColor};
-  margin: 0 0 0 10px;
+  margin-inline: 10px 0;
   line-height: initial;
-
-  ${isRTL() &&
-    css`
-      margin: 0 10px 0 0;
-    `}
 `;
 
 export const SubBoxContentStyled = styled.div``;

--- a/src/components/OfferCard/OfferCardStyled.js
+++ b/src/components/OfferCard/OfferCardStyled.js
@@ -1,5 +1,6 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { mediaFrom } from 'styles/BreakPoints';
+import { isRTL } from 'styles/RTLHelper';
 import {
   BoldFont,
   MediumFont,
@@ -63,6 +64,11 @@ export const PriceWrapperStyled = styled.div.attrs(() => ({
   display: flex;
   flex-direction: column;
   margin: auto 0 auto auto;
+
+  ${isRTL() &&
+    css`
+      margin: auto auto auto 0;
+    `}
 `;
 
 export const TrialBadgeStyled = styled.div.attrs(() => ({
@@ -105,6 +111,11 @@ export const BoxTextStyled = styled.p.attrs(() => ({
   color: ${FontColor};
   margin: 0 0 0 10px;
   line-height: initial;
+
+  ${isRTL() &&
+    css`
+      margin: 0 10px 0 0;
+    `}
 `;
 
 export const SubBoxContentStyled = styled.div``;

--- a/src/components/OfferCheckoutCard/OfferCheckoutCardStyled.js
+++ b/src/components/OfferCheckoutCard/OfferCheckoutCardStyled.js
@@ -60,15 +60,16 @@ export const PriceWrapperStyled = styled.div.attrs(() => ({
 }))`
   display: flex;
   flex-direction: column;
-  margin: auto 0 auto auto;
+  margin-inline: auto 0;
+  margin-block: auto;
 `;
 
 export const TrialBadgeStyled = styled.div.attrs(() => ({
   className: 'msd__checkout-card-price__badge'
 }))`
-  width: 80px;
+  max-width: 120px;
   padding: 4px 8px;
-  margin-bottom: 4px;
+  margin-bottom: 12px;
   background-color: ${White};
   color: ${FontColor};
   border: 1px solid ${LineColor};
@@ -77,4 +78,5 @@ export const TrialBadgeStyled = styled.div.attrs(() => ({
   font-size: ${MicroFont};
   font-weight: ${MediumFontWeight};
   text-transform: uppercase;
+  text-align: center;
 `;

--- a/src/components/PauseSubscriptionPopup/PauseSubscriptionPopupStyled.js
+++ b/src/components/PauseSubscriptionPopup/PauseSubscriptionPopupStyled.js
@@ -1,6 +1,7 @@
 import styled, { css } from 'styled-components';
 import SubscriptionIcon from 'components/SubscriptionIcon';
 import { LineColor, ConfirmColor } from 'styles/variables';
+import { isRTL } from 'styles/RTLHelper';
 
 export const SubscriptionIconStyled = styled(SubscriptionIcon)`
   display: flex;
@@ -54,6 +55,11 @@ export const ArrowStyled = styled.span`
   border-right: 2px solid ${LineColor};
 
   transform: translateX(-25%) rotate(45deg);
+
+  ${isRTL() &&
+    css`
+      transform: translateX(-25%) rotate(225deg);
+    `}
 `;
 
 export const ImageStyled = styled.img``;

--- a/src/components/Payment/DropInSection/DropInSectionStyled.js
+++ b/src/components/Payment/DropInSection/DropInSectionStyled.js
@@ -1,8 +1,7 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import * as colors from 'styles/variables';
 import { media } from 'styles/BreakPoints';
 import { ConfirmColor } from 'styles/variables';
-import { isRTL } from 'styles/RTLHelper';
 
 export const WrapperStyled = styled.div.attrs(() => ({
   className: 'msd__custom-dropin--wrapper'
@@ -41,12 +40,8 @@ export const TextStyled = styled.div.attrs(() => ({
   display: flex;
   align-items: center;
   position: relative;
-  padding: 12px 16px 12px 50px;
-
-  ${isRTL() &&
-    css`
-      padding: 12px 50px 12px 16px;
-    `}
+  padding-block: 12px;
+  padding-inline: 50px 16px;
 
   ${media.small`
     max-width: 400px;
@@ -56,13 +51,7 @@ export const TextStyled = styled.div.attrs(() => ({
 export const TitleStyled = styled.span.attrs(() => ({
   className: 'msd__custom-dropin-title'
 }))`
-  margin-left: 10px;
-
-  ${isRTL() &&
-    css`
-      margin-left: 0;
-      margin-right: 10px;
-    `}
+  margin-inline-start: 10px;
 `;
 
 export const IconWrapperStyled = styled.div.attrs(() => ({

--- a/src/components/Payment/DropInSection/DropInSectionStyled.js
+++ b/src/components/Payment/DropInSection/DropInSectionStyled.js
@@ -1,7 +1,8 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import * as colors from 'styles/variables';
 import { media } from 'styles/BreakPoints';
 import { ConfirmColor } from 'styles/variables';
+import { isRTL } from 'styles/RTLHelper';
 
 export const WrapperStyled = styled.div.attrs(() => ({
   className: 'msd__custom-dropin--wrapper'
@@ -41,6 +42,12 @@ export const TextStyled = styled.div.attrs(() => ({
   align-items: center;
   position: relative;
   padding: 12px 16px 12px 50px;
+
+  ${isRTL() &&
+    css`
+      padding: 12px 50px 12px 16px;
+    `}
+
   ${media.small`
     max-width: 400px;
   `}
@@ -50,6 +57,12 @@ export const TitleStyled = styled.span.attrs(() => ({
   className: 'msd__custom-dropin-title'
 }))`
   margin-left: 10px;
+
+  ${isRTL() &&
+    css`
+      margin-left: 0;
+      margin-right: 10px;
+    `}
 `;
 
 export const IconWrapperStyled = styled.div.attrs(() => ({

--- a/src/components/PaymentCard/PaymentCardStyled.js
+++ b/src/components/PaymentCard/PaymentCardStyled.js
@@ -1,7 +1,6 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { White, FontColor } from 'styles/variables';
 import { mediaFrom } from 'styles/BreakPoints';
-import { isRTL } from 'styles/RTLHelper';
 
 export const CardStyled = styled.div.attrs(() => ({
   className: 'msd__payment-card'
@@ -56,13 +55,7 @@ export const CardExpirationLabel = styled.div.attrs(() => ({
   font-size: 13px;
   font-weight: 300;
   margin-bottom: 4px;
-  margin-right: 4px;
-
-  ${isRTL() &&
-    css`
-      margin-right: 0;
-      margin-left: 4px;
-    `}
+  margin-inline-end: 4px;
 `;
 
 export const CardExpirationDateStyled = styled.div.attrs(() => ({
@@ -112,14 +105,7 @@ export const CardInfoStyled = styled.div.attrs(() => ({
 export const CardDetailsStyled = styled.div.attrs(() => ({
   className: 'msd__payment-method__details'
 }))`
-  margin-left: 20px;
-  margin-right: auto;
-
-  ${isRTL() &&
-    css`
-      margin-left: auto;
-      margin-right: 20px;
-    `}
+  margin-inline: 20px auto;
 `;
 
 export const CardDetailsNameStyled = styled.div.attrs(() => ({
@@ -129,13 +115,7 @@ export const CardDetailsNameStyled = styled.div.attrs(() => ({
   font-size: 13px;
   font-weight: 600;
   line-height: 20px;
-  margin-right: 4px;
-
-  ${isRTL() &&
-    css`
-      margin-right: 0;
-      margin-left: 4px;
-    `}
+  margin-inline-end: 4px;
 `;
 
 export const CardDetailsNameWrapStyled = styled.div.attrs(() => ({

--- a/src/components/PaymentCard/PaymentCardStyled.js
+++ b/src/components/PaymentCard/PaymentCardStyled.js
@@ -1,6 +1,7 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { White, FontColor } from 'styles/variables';
 import { mediaFrom } from 'styles/BreakPoints';
+import { isRTL } from 'styles/RTLHelper';
 
 export const CardStyled = styled.div.attrs(() => ({
   className: 'msd__payment-card'
@@ -56,6 +57,12 @@ export const CardExpirationLabel = styled.div.attrs(() => ({
   font-weight: 300;
   margin-bottom: 4px;
   margin-right: 4px;
+
+  ${isRTL() &&
+    css`
+      margin-right: 0;
+      margin-left: 4px;
+    `}
 `;
 
 export const CardExpirationDateStyled = styled.div.attrs(() => ({
@@ -107,6 +114,12 @@ export const CardDetailsStyled = styled.div.attrs(() => ({
 }))`
   margin-left: 20px;
   margin-right: auto;
+
+  ${isRTL() &&
+    css`
+      margin-left: auto;
+      margin-right: 20px;
+    `}
 `;
 
 export const CardDetailsNameStyled = styled.div.attrs(() => ({
@@ -117,6 +130,12 @@ export const CardDetailsNameStyled = styled.div.attrs(() => ({
   font-weight: 600;
   line-height: 20px;
   margin-right: 4px;
+
+  ${isRTL() &&
+    css`
+      margin-right: 0;
+      margin-left: 4px;
+    `}
 `;
 
 export const CardDetailsNameWrapStyled = styled.div.attrs(() => ({

--- a/src/components/ResumeSubscriptionPopup/ResumeSubscriptionPopupStyled.js
+++ b/src/components/ResumeSubscriptionPopup/ResumeSubscriptionPopupStyled.js
@@ -1,6 +1,7 @@
 import styled, { css } from 'styled-components';
 import SubscriptionIcon from 'components/SubscriptionIcon';
 import { LineColor, ConfirmColor } from 'styles/variables';
+import { isRTL } from 'styles/RTLHelper';
 
 export const SubscriptionIconStyled = styled(SubscriptionIcon)`
   display: flex;
@@ -54,6 +55,11 @@ export const ArrowStyled = styled.span`
   border-right: 2px solid ${LineColor};
 
   transform: translateX(-25%) rotate(45deg);
+
+  ${isRTL() &&
+    css`
+      transform: translateX(-25%) rotate(225deg);
+    `}
 `;
 
 export const ImageStyled = styled.img``;

--- a/src/components/SubscriptionIcon/SubscriptionIconStyled.js
+++ b/src/components/SubscriptionIcon/SubscriptionIconStyled.js
@@ -1,5 +1,6 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { mediaFrom } from 'styles/BreakPoints';
+import { isRTL } from 'styles/RTLHelper';
 import { BoldFont, FontColor, White, ConfirmColor } from 'styles/variables';
 
 export const WrapperStyled = styled.div.attrs(() => ({
@@ -37,6 +38,16 @@ export const WrapperStyled = styled.div.attrs(() => ({
     
     font-size: 20px;
   `}
+
+  ${isRTL() &&
+    css`
+      margin-right: 0;
+      margin-left: 10px;
+      ${mediaFrom.small`
+        margin-right: 0;
+        margin-left: 15px;
+      `}
+    `}
 `;
 
 export const LabelStyled = styled.span`

--- a/src/components/SubscriptionIcon/SubscriptionIconStyled.js
+++ b/src/components/SubscriptionIcon/SubscriptionIconStyled.js
@@ -1,6 +1,5 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { mediaFrom } from 'styles/BreakPoints';
-import { isRTL } from 'styles/RTLHelper';
 import { BoldFont, FontColor, White, ConfirmColor } from 'styles/variables';
 
 export const WrapperStyled = styled.div.attrs(() => ({
@@ -10,7 +9,7 @@ export const WrapperStyled = styled.div.attrs(() => ({
   justify-content: center;
   position: relative;
   padding: 10px;
-  margin-right: 10px;
+  margin-inline-end: 10px;
   border-radius: 8px;
   flex: 0 0 40px;
 
@@ -33,21 +32,11 @@ export const WrapperStyled = styled.div.attrs(() => ({
 
   ${mediaFrom.small`
     flex: 0 0 50px;
-    margin-right: 15px;
+    margin-inline-end: 15px;
     padding: 14px 10px;
     
     font-size: 20px;
   `}
-
-  ${isRTL() &&
-    css`
-      margin-right: 0;
-      margin-left: 10px;
-      ${mediaFrom.small`
-        margin-right: 0;
-        margin-left: 15px;
-      `}
-    `}
 `;
 
 export const LabelStyled = styled.span`

--- a/src/components/SwitchPlanPopup/SwitchPlanPopupStyled.js
+++ b/src/components/SwitchPlanPopup/SwitchPlanPopupStyled.js
@@ -1,6 +1,7 @@
 import styled, { css } from 'styled-components';
 import SubscriptionIcon from 'components/SubscriptionIcon';
 import { LineColor } from 'styles/variables';
+import { isRTL } from 'styles/RTLHelper';
 
 export const SubscriptionIconStyled = styled(SubscriptionIcon)`
   flex: 0 0 70px;
@@ -37,6 +38,11 @@ export const ArrowStyled = styled.span`
   border-right: 2px solid ${LineColor};
 
   transform: translateX(-25%) rotate(45deg);
+
+  ${isRTL() &&
+    css`
+      transform: translateX(-25%) rotate(225deg);
+    `}
 `;
 
 export const ImageStyled = styled.img``;

--- a/src/components/Transactions/TransactionsStyled.js
+++ b/src/components/Transactions/TransactionsStyled.js
@@ -63,13 +63,11 @@ export const RightBoxStyled = styled.div`
   flex-direction: column;
   justify-content: space-between;
   flex-shrink: 0;
-  margin-left: 20px;
+  margin-inline-start: 20px;
   text-align: right;
 
-  ${isRTL() &&
+  ${isRTL &&
     css`
-      margin-left: 0;
-      margin-right: 20px;
       text-align: left;
     `}
 `;
@@ -145,11 +143,5 @@ export const LogoWrapStyled = styled.div`
 `;
 
 export const InfoStyled = styled.div`
-  margin-left: 18px;
-
-  ${isRTL() &&
-    css`
-      margin-left: 0;
-      margin-right: 18px;
-    `}
+  margin-inline-start: 18px;
 `;

--- a/src/components/Transactions/TransactionsStyled.js
+++ b/src/components/Transactions/TransactionsStyled.js
@@ -2,7 +2,6 @@
 import styled, { css } from 'styled-components';
 import { LineColor, FontColor } from 'styles/variables';
 import { media } from 'styles/BreakPoints';
-import { isRTL } from 'styles/RTLHelper';
 
 export const WrapStyled = styled.div.attrs(() => ({
   className: 'msd__transactions__wrapper'
@@ -64,12 +63,7 @@ export const RightBoxStyled = styled.div`
   justify-content: space-between;
   flex-shrink: 0;
   margin-inline-start: 20px;
-  text-align: right;
-
-  ${isRTL &&
-    css`
-      text-align: left;
-    `}
+  text-align: end;
 `;
 
 export const TitleStyled = styled.h3.attrs(() => ({

--- a/src/components/Transactions/TransactionsStyled.js
+++ b/src/components/Transactions/TransactionsStyled.js
@@ -2,6 +2,7 @@
 import styled, { css } from 'styled-components';
 import { LineColor, FontColor } from 'styles/variables';
 import { media } from 'styles/BreakPoints';
+import { isRTL } from 'styles/RTLHelper';
 
 export const WrapStyled = styled.div.attrs(() => ({
   className: 'msd__transactions__wrapper'
@@ -64,6 +65,13 @@ export const RightBoxStyled = styled.div`
   flex-shrink: 0;
   margin-left: 20px;
   text-align: right;
+
+  ${isRTL() &&
+    css`
+      margin-left: 0;
+      margin-right: 20px;
+      text-align: left;
+    `}
 `;
 
 export const TitleStyled = styled.h3.attrs(() => ({
@@ -138,4 +146,10 @@ export const LogoWrapStyled = styled.div`
 
 export const InfoStyled = styled.div`
   margin-left: 18px;
+
+  ${isRTL() &&
+    css`
+      margin-left: 0;
+      margin-right: 18px;
+    `}
 `;

--- a/src/components/UpdatePaymentDetailsPopup/UpdatePaymentDetailsPopupStyled.js
+++ b/src/components/UpdatePaymentDetailsPopup/UpdatePaymentDetailsPopupStyled.js
@@ -47,7 +47,7 @@ export const RemoveLinkStyled = styled.a.attrs(() => ({
 `;
 
 export const DeleteIconStyled = styled(props => <DeleteIcon {...props} />)`
-  margin-right: 10px;
+  margin-inline-end: 10px;
   font-size: 9px;
 `;
 

--- a/src/styles/RTLHelper.js
+++ b/src/styles/RTLHelper.js
@@ -1,0 +1,4 @@
+// eslint-disable-next-line import/prefer-default-export
+export const isRTL = () => {
+  return document.dir === 'rtl';
+};

--- a/src/styles/RTLHelper.js
+++ b/src/styles/RTLHelper.js
@@ -1,4 +1,2 @@
 // eslint-disable-next-line import/prefer-default-export
-export const isRTL = () => {
-  return document.dir === 'rtl';
-};
+export const isRTL = () => document.dir === 'rtl';


### PR DESCRIPTION
### Description

Add support for dir="rtl" attribute in mediastore-sdk library

### Updates
- adding new helper `isRTL()` that will return true if dir="rtl" is set in the document
- based on the document.dir value add some style alignment (margins, paddings)

### Screenshots
<img width="633" alt="image" src="https://github.com/Cleeng/mediastore-sdk/assets/19149811/a25a2f07-bea3-44ec-b49d-dbd851a02a40">
<img width="879" alt="image" src="https://github.com/Cleeng/mediastore-sdk/assets/19149811/e4cfb8d8-66a0-4586-aabb-e726769800b4">
<img width="879" alt="image" src="https://github.com/Cleeng/mediastore-sdk/assets/19149811/11a07e7a-5456-4944-87e1-0d69b2be5012">
<img width="879" alt="image" src="https://github.com/Cleeng/mediastore-sdk/assets/19149811/426c3ff2-c943-43f4-a8bc-5826804e3903">

<img width="879" alt="image" src="https://github.com/Cleeng/mediastore-sdk/assets/19149811/16f08707-ac43-42c0-bc9a-433d2da90936">



### Testing

### Additional Notes
