### PR TITLE
Add get offer V2

### DIFF
--- a/src/api/Offers/getOffer.ts
+++ b/src/api/Offers/getOffer.ts
@@ -1,0 +1,24 @@
+import fetchWithJWT from 'util/fetchHelper';
+import getApiURL from 'util/environmentHelper';
+import OfferV2 from 'types/OfferV2.types';
+
+const getOffer = async (offerId: string): Promise<OfferV2> => {
+  const API_URL = getApiURL();
+
+  const url = `${API_URL}/v2/offers/${offerId}`;
+  return fetchWithJWT(url, {
+    method: 'GET'
+  })
+    .then(async res => {
+      const { responseData, errors } = await res.json();
+      if (!res.ok) {
+        throw new Error(errors[0]);
+      }
+      return responseData;
+    })
+    .catch(err => {
+      throw new Error(err);
+    });
+};
+
+export default getOffer;

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -28,6 +28,7 @@ import updatePayPalPaymentDetails from './PaymentDetails/updatePayPalPaymentDeta
 import finalizeInitialPayment from './Payment/finalizeInitialPayment';
 import finalizeAddPaymentDetails from './Payment/finalizeAddPaymentDetails';
 import getOffers from './Offers/getOffers';
+import getOffer from './Offers/getOffer';
 
 export {
   getPaymentDetails,
@@ -59,5 +60,6 @@ export {
   finalizeInitialPayment,
   finalizeAddPaymentDetails,
   getOffers,
+  getOffer,
   getSwitch
 };

--- a/src/containers/OfferContainer/OfferContainer.tsx
+++ b/src/containers/OfferContainer/OfferContainer.tsx
@@ -9,7 +9,12 @@ import { updateOrder, getPaymentMethods } from 'api';
 import { setData, getData, removeData } from 'util/appConfigHelper';
 import { useAppDispatch, useAppSelector } from 'redux/store';
 import { unwrapResult } from '@reduxjs/toolkit';
-import { fetchOffer, setFreeOffer, selectOffer } from 'redux/offerSlice';
+import {
+  fetchOffer,
+  fetchOfferV2,
+  setFreeOffer,
+  selectOffer
+} from 'redux/offerSlice';
 import {
   init as initValues,
   selectPublisherConfig
@@ -151,6 +156,10 @@ const OfferContainer = ({
 
     const init = async () => {
       const resultOfferAction = await dispatch(fetchOffer(offerId));
+      const resultOfferV2Action = await dispatch(
+        fetchOfferV2(offerId.split('_')[0])
+      );
+      console.log(resultOfferV2Action);
       const { offerId: id } = unwrapResult(resultOfferAction);
       setData('CLEENG_OFFER_ID', id);
       setData('CLEENG_OFFER_TYPE', id.charAt(0));

--- a/src/redux/offerSlice.ts
+++ b/src/redux/offerSlice.ts
@@ -1,10 +1,12 @@
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { OfferV2 } from 'types/OfferV2.types';
 import { RootState } from './rootReducer';
-import { getOfferDetails } from '../api';
+import { getOfferDetails, getOffer } from '../api';
 import { Offer, OfferInitialState } from './types';
 
 const initialState: OfferInitialState = {
   offer: {},
+  offerV2: {},
   loading: false,
   error: null,
   isOfferFree: false
@@ -20,6 +22,22 @@ export const fetchOffer = createAsyncThunk<
   try {
     const result = await getOfferDetails(orderId);
     return result as Offer;
+  } catch (err) {
+    const typedError = err as Error;
+    return rejectWithValue(typedError.message);
+  }
+});
+
+export const fetchOfferV2 = createAsyncThunk<
+  OfferV2,
+  string,
+  {
+    rejectValue: string;
+  }
+>('offer/fetchOfferV2', async (orderId, { rejectWithValue }) => {
+  try {
+    const result = await getOffer(orderId);
+    return result as OfferV2;
   } catch (err) {
     const typedError = err as Error;
     return rejectWithValue(typedError.message);
@@ -43,6 +61,19 @@ export const offerSlice = createSlice({
       state.offer = action.payload;
     });
     builder.addCase(fetchOffer.rejected, (state, action) => {
+      state.loading = false;
+      if (action.payload) {
+        state.error = action.payload;
+      }
+    });
+    builder.addCase(fetchOfferV2.pending, state => {
+      state.loading = true;
+    });
+    builder.addCase(fetchOfferV2.fulfilled, (state, action) => {
+      state.loading = false;
+      state.offerV2 = action.payload;
+    });
+    builder.addCase(fetchOfferV2.rejected, (state, action) => {
       state.loading = false;
       if (action.payload) {
         state.error = action.payload;

--- a/src/redux/types/offerSlice.types.ts
+++ b/src/redux/types/offerSlice.types.ts
@@ -1,3 +1,5 @@
+import { OfferV2 } from 'types/OfferV2.types';
+
 export type Offer = {
   accessToTags: string[];
   active: boolean;
@@ -43,6 +45,7 @@ export type Offer = {
 
 export type OfferInitialState = {
   offer: Offer | Record<string, never>;
+  offerV2: OfferV2 | Record<string, never>;
   loading: boolean;
   error: string | null | undefined;
   isOfferFree: boolean;

--- a/src/types/OfferType.types.ts
+++ b/src/types/OfferType.types.ts
@@ -1,0 +1,1 @@
+export type OfferType = 'subscription' | 'pass' | 'live' | 'vod';

--- a/src/types/OfferV2.types.ts
+++ b/src/types/OfferV2.types.ts
@@ -1,0 +1,77 @@
+import { Price } from './Price.types';
+import { OfferType } from './OfferType.types';
+
+export type GeoRestriction = {
+  type: string;
+  countries: string[];
+};
+
+export type BillingCycle = {
+  periodUnit: string;
+  amount: number;
+};
+
+export type Entitlement = {
+  expirationPolicy: string;
+  expiresAt?: number;
+  duration?: {
+    amount: number;
+    periodUnit: string;
+  };
+};
+
+export type Event = {
+  startsAt: number;
+  endsAt: number;
+  timezone: string;
+};
+
+export type FreeTrial = {
+  type: 'day' | 'period';
+  duration: number;
+};
+
+export type ExternalProperties = {
+  [key: string]: string | number;
+};
+
+export type AppStoreProductIds = {
+  apple?: string;
+  android?: string;
+};
+
+export type Localization = {
+  id: string;
+  title: string;
+  description: string;
+  countryCode: string;
+  price: Price;
+  freeTrial?: FreeTrial;
+  geoRestriction: GeoRestriction[];
+};
+
+export type OfferV2 = {
+  id: string;
+  title: string;
+  description: string;
+  price: Price;
+  active: boolean;
+  type: OfferType;
+  geoRestriction: GeoRestriction[];
+  tags: string[];
+  billingCycle?: BillingCycle;
+  entitlement?: Entitlement;
+  event?: Event;
+  freeTrial?: FreeTrial;
+  createdAt: number;
+  updatedAt: number;
+  externalProperties: ExternalProperties;
+  appStoreProductIds: AppStoreProductIds;
+  imageUrl: string;
+  hasLandingPage: boolean;
+  localizations: Localization[];
+  sessionsLimit: number;
+  giftable: boolean;
+};
+
+export default OfferV2;

--- a/src/types/Price.types.ts
+++ b/src/types/Price.types.ts
@@ -1,0 +1,7 @@
+export type Price = {
+  amount: number;
+  currency: string;
+  taxIncluded: boolean;
+};
+
+export default Price;


### PR DESCRIPTION
### Description

Add call to the `v2/offers/{offerId}` in the Purchase component

### Updates

- add new `getOffer` api method
- add `offerV2` entry in the Redux not to override the previous offer details
- add `createAsyncThunk` in the `offerSlice.ts` that will menage offer request
- dispatch `fetchOfferV2` method in the OfferContainer component
- add separate `types/` folder to store some common types like `Price`, `OfferV2` etc.

### Screenshots

### Testing

### Additional Notes
