### PR TITLE
fix/MSSDK-1468: CouponInput focus styles and sequential navigation

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import { forwardRef } from 'react';
 import ButtonStyled from './ButtonStyled';
 
 export const BUTTON_SIZE = {
@@ -18,47 +19,55 @@ export const BUTTON_THEME = {
   DANGER: 'danger'
 };
 
-const Button = ({
-  type,
-  onClickFn,
-  disabled,
-  children,
-  label,
-  size,
-  theme,
-  fontSize,
-  margin,
-  fontWeight,
-  width,
-  icon,
-  padding,
-  className,
-  testid
-}) => {
-  const ButtonProps = {
-    type,
-    onClick: onClickFn
-  };
-  return (
-    <ButtonStyled
-      {...ButtonProps}
-      disabled={disabled}
-      aria-label={label}
-      size={size}
-      theme={theme}
-      fontSize={fontSize}
-      margin={margin}
-      fontWeight={fontWeight}
-      width={width}
-      icon={icon}
-      padding={padding}
-      className={className}
-      data-testid={testid}
-    >
-      {children}
-    </ButtonStyled>
-  );
-};
+const Button = forwardRef(
+  (
+    {
+      type,
+      onClickFn,
+      disabled,
+      children,
+      label,
+      size,
+      theme,
+      fontSize,
+      margin,
+      fontWeight,
+      width,
+      icon,
+      padding,
+      className,
+      testid,
+      onFocus
+    },
+    ref
+  ) => {
+    const ButtonProps = {
+      type,
+      onClick: onClickFn
+    };
+    return (
+      <ButtonStyled
+        {...ButtonProps}
+        disabled={disabled}
+        aria-label={label}
+        size={size}
+        theme={theme}
+        fontSize={fontSize}
+        margin={margin}
+        fontWeight={fontWeight}
+        width={width}
+        icon={icon}
+        padding={padding}
+        className={className}
+        data-testid={testid}
+        ref={ref}
+        onFocus={onFocus}
+      >
+        {children}
+      </ButtonStyled>
+    );
+  }
+);
 
 Button.propTypes = {
   size: PropTypes.oneOf(Object.values(BUTTON_SIZE)),
@@ -79,7 +88,8 @@ Button.propTypes = {
   icon: PropTypes.string,
   padding: PropTypes.string,
   className: PropTypes.string,
-  testid: PropTypes.string
+  testid: PropTypes.string,
+  onFocus: PropTypes.func
 };
 
 Button.defaultProps = {
@@ -98,7 +108,9 @@ Button.defaultProps = {
   icon: null,
   padding: null,
   className: '',
-  testid: null
+  testid: null,
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  onFocus: () => {}
 };
 
 export default Button;

--- a/src/components/Button/ButtonStyled.js
+++ b/src/components/Button/ButtonStyled.js
@@ -33,7 +33,8 @@ const ButtonStyled = styled.button.attrs(props => ({
   }
 
   &:focus {
-    outline: 1px solid ${colors.FocusColor};
+    /* outline: 1px solid ${colors.FocusColor}; */
+    outline: 3px solid #ED2B2A;
   }
 
   &:disabled {

--- a/src/components/CouponInput/CouponInput.tsx
+++ b/src/components/CouponInput/CouponInput.tsx
@@ -1,4 +1,4 @@
-import { KeyboardEvent, useEffect, useState } from 'react';
+import { KeyboardEvent, useEffect, useRef, useState } from 'react';
 import { MESSAGE_TYPE_SUCCESS } from 'components/Input/InputConstants';
 import Loader from 'components/Loader';
 import Button from 'components/Button';
@@ -37,6 +37,8 @@ const CouponInput = ({
     false
   );
   const [isOpened, setIsOpened] = useState(false);
+
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
   const { t } = useTranslation();
   const {
@@ -120,64 +122,99 @@ const CouponInput = ({
   }, [showMessage, message, messageType]);
 
   return (
-    <InputComponentStyled
-      isOpened={isOpened}
-      fullWidth={fullWidth}
-      onSubmit={async e => {
-        e.preventDefault();
-        await onRedeemClick();
-      }}
-    >
-      <InputElementWrapperStyled>
-        <CloseButtonStyled
-          onClick={() => onCloseClick()}
-          isInputOpened={isOpened}
-          aria-label="close"
-          type="button"
-        >
-          {CloseIcon && <CloseIcon />}
-        </CloseButtonStyled>
-        <InputElementStyled
-          isOpened={isOpened}
-          placeholder={t('coupon-input.placeholder', 'Your coupon') as string}
-          onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
-            if (event.key === 'Enter') {
-              handleSubmit(event);
+    <>
+      <Button type="button" onFocus={() => console.log('Button focused!!!')}>
+        Click here
+      </Button>
+      {/* <button
+        type="button"
+        ref={buttonRef}
+        onClick={() => console.log('btn ref', buttonRef.current)}
+      >
+        Check the ref
+      </button> */}
+      <InputComponentStyled
+        // tabIndex={-1}
+        isOpened={isOpened}
+        fullWidth={fullWidth}
+        onSubmit={async e => {
+          e.preventDefault();
+          await onRedeemClick();
+        }}
+        onClick={() => {
+          console.log('Form clicked()');
+        }}
+        // onFocus={() => {
+        //   console.log('focus on outer form elemetn');
+        //   console.log('btnRef:', buttonRef.current);
+        //   buttonRef.current?.focus();
+        // }}
+      >
+        <InputElementWrapperStyled>
+          <CloseButtonStyled
+            onClick={() => onCloseClick()}
+            isInputOpened={isOpened}
+            aria-label="close"
+            type="button"
+            onFocus={() => {
+              console.log('close button clicked');
+              console.log('btnRef from CloseButton:', buttonRef.current);
+              // buttonRef.current?.focus();
+            }}
+          >
+            {CloseIcon && <CloseIcon />}
+          </CloseButtonStyled>
+          <InputElementStyled
+            isOpened={isOpened}
+            placeholder={t('coupon-input.placeholder', 'Your coupon') as string}
+            onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
+              if (event.key === 'Enter') {
+                handleSubmit(event);
+              }
+            }}
+            onFocus={() => {
+              setSuppressMessage(true);
+              console.log('inner input element clicked');
+            }}
+            autoComplete="off"
+            value={value}
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+              onChange(event.target.value)
             }
-          }}
-          onFocus={() => {
-            setSuppressMessage(true);
-          }}
-          autoComplete="off"
-          value={value}
-          onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-            onChange(event.target.value)
-          }
-          type="text"
-          readOnly={couponLoading}
-          fullWidth={fullWidth}
-          aria-label={t('coupon-input.placeholder', 'Your coupon') as string}
-          aria-required={false}
-        />
-        <Button width="auto" testid="redeem-btn" type="submit">
-          <>
-            {couponLoading && <Loader buttonLoader color="#ffffff" />}
-            {!couponLoading && isOpened && t('coupon-input.redeem', 'Redeem')}
-            {!couponLoading &&
-              !isOpened &&
-              t('coupon-input.redeem-coupon', 'Redeem coupon')}
-          </>
-        </Button>
-      </InputElementWrapperStyled>
-      {isOpened && (
-        <MessageStyled
-          showMessage={showMessage && !suppressMessage}
-          messageType={messageType}
-        >
-          {t(translationKey, message)}
-        </MessageStyled>
-      )}
-    </InputComponentStyled>
+            type="text"
+            readOnly={couponLoading}
+            fullWidth={fullWidth}
+            aria-label={t('coupon-input.placeholder', 'Your coupon') as string}
+            aria-required={false}
+          />
+          <Button
+            // tabIndex={1}
+            width="auto"
+            testid="redeem-btn"
+            type="submit"
+            ref={buttonRef}
+            onClickFn={() => console.log('btn ref', buttonRef.current)}
+            onFocus={() => console.log('the deep button focused')}
+          >
+            <>
+              {couponLoading && <Loader buttonLoader color="#ffffff" />}
+              {!couponLoading && isOpened && t('coupon-input.redeem', 'Redeem')}
+              {!couponLoading &&
+                !isOpened &&
+                t('coupon-input.redeem-coupon', 'Redeem coupon')}
+            </>
+          </Button>
+        </InputElementWrapperStyled>
+        {isOpened && (
+          <MessageStyled
+            showMessage={showMessage && !suppressMessage}
+            messageType={messageType}
+          >
+            {t(translationKey, message)}
+          </MessageStyled>
+        )}
+      </InputComponentStyled>
+    </>
   );
 };
 

--- a/src/components/CouponInput/CouponInput.tsx
+++ b/src/components/CouponInput/CouponInput.tsx
@@ -6,7 +6,7 @@ import { ReactComponent as CloseIcon } from 'assets/images/xmark.svg';
 import { useTranslation } from 'react-i18next';
 import { MSSDK_COUPON_FAILED } from 'util/eventDispatcher';
 import {
-  InputComponentStyled,
+  FormComponentStyled,
   MessageStyled,
   InputElementWrapperStyled,
   InputElementStyled,
@@ -38,6 +38,8 @@ const CouponInput = ({
     false
   );
   const [isOpened, setIsOpened] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
+  const [isInputFocused, setIsInputFocused] = useState(false);
 
   const buttonRef = useRef<HTMLButtonElement>(null);
 
@@ -102,6 +104,7 @@ const CouponInput = ({
   };
 
   const onCloseClick = () => {
+    setIsFocused(false);
     if (isOpened) {
       setIsOpened(false);
       if (onClose) onClose();
@@ -132,99 +135,78 @@ const CouponInput = ({
   }, [showMessage, message, messageType]);
 
   return (
-    <>
-      <Button type="button" onFocus={() => console.log('Button focused!!!')}>
-        Click here
-      </Button>
-      {/* <button
-        type="button"
-        ref={buttonRef}
-        onClick={() => console.log('btn ref', buttonRef.current)}
-      >
-        Check the ref
-      </button> */}
-      <InputComponentStyled
-        // tabIndex={-1}
-        isOpened={isOpened}
-        fullWidth={fullWidth}
-        onSubmit={async e => {
-          e.preventDefault();
-          await onRedeemClick();
-        }}
-        onClick={() => {
-          console.log('Form clicked()');
-        }}
-        // onFocus={() => {
-        //   console.log('focus on outer form elemetn');
+    <FormComponentStyled
+      isOpened={isOpened}
+      fullWidth={fullWidth}
+      onSubmit={async e => {
+        e.preventDefault();
+        await onRedeemClick();
+      }}
+      onFocus={() => {
+        // console.log('focus on outer form element');
         //   console.log('btnRef:', buttonRef.current);
-        //   buttonRef.current?.focus();
-        // }}
+        if (!isFocused) {
+          buttonRef.current?.focus();
+          console.log('focus set!');
+          setIsFocused(true);
+        }
+      }}
+    >
+      <InputElementWrapperStyled
+        isInputFocused={isInputFocused}
+        isInputOpened={isOpened}
       >
-        <InputElementWrapperStyled>
-          <CloseButtonStyled
-            onClick={() => onCloseClick()}
-            isInputOpened={isOpened}
-            aria-label="close"
-            type="button"
-            onFocus={() => {
-              console.log('close button clicked');
-              console.log('btnRef from CloseButton:', buttonRef.current);
-              // buttonRef.current?.focus();
-            }}
-          >
-            {CloseIcon && <CloseIcon />}
-          </CloseButtonStyled>
-          <InputElementStyled
-            isOpened={isOpened}
-            placeholder={t('coupon-input.placeholder', 'Your coupon') as string}
-            onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
-              if (event.key === 'Enter') {
-                handleSubmit(event);
-              }
-            }}
-            onFocus={() => {
-              setSuppressMessage(true);
-              console.log('inner input element clicked');
-            }}
-            autoComplete="off"
-            value={value}
-            onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-              onChange(event.target.value)
+        <CloseButtonStyled
+          onClick={() => onCloseClick()}
+          isInputOpened={isOpened}
+          aria-label="close"
+          type="button"
+        >
+          {CloseIcon && <CloseIcon />}
+        </CloseButtonStyled>
+        <InputElementStyled
+          isOpened={isOpened}
+          placeholder={t('coupon-input.placeholder', 'Your coupon') as string}
+          onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
+            if (event.key === 'Enter') {
+              handleSubmit(event);
             }
-            type="text"
-            readOnly={couponLoading}
-            fullWidth={fullWidth}
-            aria-label={t('coupon-input.placeholder', 'Your coupon') as string}
-            aria-required={false}
-          />
-          <Button
-            // tabIndex={1}
-            width="auto"
-            testid="redeem-btn"
-            type="submit"
-            ref={buttonRef}
-            onClickFn={() => console.log('btn ref', buttonRef.current)}
-            onFocus={() => console.log('the deep button focused')}
-          >
-            <>
-              {couponLoading && <Loader buttonLoader color="#ffffff" />}
-              {!couponLoading && isOpened && t('coupon-input.redeem', 'Redeem')}
-              {!couponLoading &&
-                !isOpened &&
-                t('coupon-input.redeem-coupon', 'Redeem coupon')}
-            </>
-          </Button>
-        </InputElementWrapperStyled>
-        {isOpened && (
-          <MessageStyled
-            showMessage={showMessage && !suppressMessage}
-            messageType={messageType}
-          >
-            {t(translationKey, message)}
-          </MessageStyled>
-        )}
-      </InputComponentStyled>
-    </>
+          }}
+          onFocus={() => {
+            setSuppressMessage(true);
+            setIsInputFocused(true);
+          }}
+          onBlur={() => setIsInputFocused(false)}
+          autoComplete="off"
+          value={value}
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+            onChange(event.target.value)
+          }
+          type="text"
+          readOnly={couponLoading}
+          fullWidth={fullWidth}
+          aria-label={t('coupon-input.placeholder', 'Your coupon') as string}
+          aria-required={false}
+        />
+        <Button width="auto" testid="redeem-btn" type="submit" ref={buttonRef}>
+          <>
+            {couponLoading && <Loader buttonLoader color="#ffffff" />}
+            {!couponLoading && isOpened && t('coupon-input.redeem', 'Redeem')}
+            {!couponLoading &&
+              !isOpened &&
+              t('coupon-input.redeem-coupon', 'Redeem coupon')}
+          </>
+        </Button>
+      </InputElementWrapperStyled>
+      {isOpened && (
+        <MessageStyled
+          showMessage={showMessage && !suppressMessage}
+          messageType={messageType}
+        >
+          {t(translationKey, message)}
+        </MessageStyled>
+      )}
+    </FormComponentStyled>
   );
 };
 

--- a/src/components/CouponInput/CouponInput2.tsx
+++ b/src/components/CouponInput/CouponInput2.tsx
@@ -1,0 +1,61 @@
+import { KeyboardEvent, useEffect, useRef, useState } from 'react';
+import { MESSAGE_TYPE_SUCCESS } from 'components/Input/InputConstants';
+import Loader from 'components/Loader';
+import Button from 'components/Button';
+import { ReactComponent as CloseIcon } from 'assets/images/xmark.svg';
+import { useTranslation } from 'react-i18next';
+import { MSSDK_COUPON_FAILED } from 'util/eventDispatcher';
+import {
+  FormComponentStyled,
+  MessageStyled,
+  InputElementWrapperStyled,
+  InputElementStyled,
+  CloseButtonStyled
+} from './CouponInputStyled';
+
+import { CouponInputProps } from './CouponInput.types';
+
+const FADE_OUT_DELAY = 5000;
+
+const CouponInput = ({
+  value = '',
+  fullWidth = false,
+  couponDetails = {
+    showMessage: false,
+    message: '',
+    messageType: MESSAGE_TYPE_SUCCESS,
+    translationKey: ''
+  },
+  onSubmit,
+  onChange,
+  onClose,
+  onInputToggle,
+  couponLoading,
+  source = ''
+}: CouponInputProps) => {
+  const { t } = useTranslation();
+  return (
+    <FormComponentStyled isOpened fullWidth>
+      <InputElementWrapperStyled isInputOpened="true">
+        <CloseButtonStyled
+          type="button"
+          aria-label="close"
+          isInputOpened="true"
+        >
+          {CloseIcon && <CloseIcon />}
+        </CloseButtonStyled>
+        <InputElementStyled
+          type="text"
+          placeholder={t('coupon-input.placeholder', 'Your coupon') as string}
+          isOpened
+          fullWidth
+        />
+        <Button type="button" width="auto" testid="redeem-btn">
+          Redeem coupon
+        </Button>
+      </InputElementWrapperStyled>
+    </FormComponentStyled>
+  );
+};
+
+export default CouponInput;

--- a/src/components/CouponInput/CouponInputStyled.ts
+++ b/src/components/CouponInput/CouponInputStyled.ts
@@ -57,8 +57,11 @@ export const InputElementWrapperStyled = styled.div.attrs(() => ({
   background: white;
   transition: 0.2s ease-in-out;
 
-  &:focus-within {
+  /* &:focus-within {
     border-color: ${Colors.FocusColor};
+  } */
+  &:focus {
+    outline: 1px solid #fab;
   }
 `;
 

--- a/src/components/CouponInput/CouponInputStyled.ts
+++ b/src/components/CouponInput/CouponInputStyled.ts
@@ -9,7 +9,7 @@ import {
   CloseButtonStyledProps
 } from './CouponInput.types';
 
-export const InputComponentStyled = styled.form.attrs(() => ({
+export const FormComponentStyled = styled.form.attrs(() => ({
   className: 'msd__coupon-input__wrapper',
   'data-testid': 'inputcomponent'
 }))<InputComponentStyledProps>`
@@ -55,14 +55,19 @@ export const InputElementWrapperStyled = styled.div.attrs(() => ({
   border-radius: 30px;
 
   background: white;
-  transition: 0.2s ease-in-out;
+  /* transition: 0.2s ease-in-out; */
 
   /* &:focus-within {
     border-color: ${Colors.FocusColor};
   } */
-  &:focus {
-    outline: 1px solid #fab;
-  }
+
+
+  ${props =>
+    props.isInputFocused &&
+    props.isInputOpened &&
+    css`
+      outline: 3px solid red;
+    `} 
 `;
 
 export const InputElementStyled = styled.input.attrs(() => ({
@@ -135,4 +140,8 @@ export const CloseButtonStyled = styled.button.attrs(() => ({
     css`
       opacity: 1;
     `}
+
+  &:focus {
+    outline: 3px solid red;
+  }
 `;

--- a/src/components/CouponInput/index.tsx
+++ b/src/components/CouponInput/index.tsx
@@ -1,3 +1,4 @@
 import CouponInput from './CouponInput';
+// import CouponInput from './CouponInput2';
 
 export default CouponInput;


### PR DESCRIPTION
### Description

The current implementation of `CouponInput `suffers from incorrect sequential focus navigation, leading to issues while browsing the page using the `tab` key. This becomes evident when users attempt to switch focus from the previous element to the `Redeem coupon` button to access the form. However, the first element that unexpectedly captures the focus is `CloseButton`, causing a suboptimal user experience.

### Updates

To resolve the issue, both `CloseButton` and the inner `Input` elements were encapsulated in conditional rendering. By doing so, these invisible components are being prevented from receiving focus in the DOM. This ensures that users can smoothly switch focus to the 'Redeem coupon' button and open the form without any unexpected detours.

### Screenshots

![image](https://github.com/Cleeng/mediastore-sdk/assets/30701167/cfd9f262-fc4b-4bc9-8a62-3476a6901666)

### Additional notes

Appropriate and accessible focus styles to be discussed w/ Design Team
