### PR TITLE
chore/MSSDK 1485 commit message verification hook

### DIFF
--- a/.husky/verify_branch_name
+++ b/.husky/verify_branch_name
@@ -1,20 +1,22 @@
 #!/bin/bash
 
-branch_name_regex='^(chore|docs|feat|fix|refactor|style|test)\/MSSDK-[[:digit:]]+((-[[:alnum:]]+)+)'
+branch_name_regex='^(chore|docs|feat|fix|refactor|style|test)\/MSSDK-([[:digit:]]|external)+((-[[:alnum:]]+)+)'
 current_branch_name="$(git rev-parse --abbrev-ref HEAD)"
 branch_template="<type>/<jira-ticket-id>-<brief-description>"
+external_branch_template="<MSSDK-external>-<brief-description>"
 branch_example="fix/MSSDK-42-remove-all-humans"
+external_branch_example='feat/MSSDK-external-restore-all-humans'
 
 invalid_branch_message="\nI'm sorry, Dave. I'm afraid I can't do that.
 The branch name \033[1;31m$current_branch_name\033[0m does not adhere to the semantic naming convention. It should match this regular expression:
-
-\t\033[1;34m$branch_name_regex\033[0m\n\nIn human terms that's:
-
-\t\033[1;34m$branch_template\033[0m
-
+\t\033[1;34m$branch_name_regex\033[0m
+In human terms that's:
+\t\033[1;34m$branch_template\033[0m 
 eg. \033[1;32m$branch_example\033[0m
 
-Please rename your branch accordingly and try again."
+Oh, and if you're an external contributor, use the following template: \033[1;35m$external_branch_template\033[0m e.g. \033[1;32m$external_branch_example\033[0m
+
+Please rename your branch accordingly and try again.\n"
 
 if ! echo "$current_branch_name" | grep -Eq $branch_name_regex
 then

--- a/.husky/verify_commit_message
+++ b/.husky/verify_commit_message
@@ -4,7 +4,7 @@ current_branch_name=$(git rev-parse --abbrev-ref HEAD)
 jira_id_regex="MSSDK-[[:digit:]]+"
 jira_id=$(printf "$current_branch_name" | grep -Eo $jira_id_regex)
 
-current_commit_name=$(cat $1)
+current_commit_name=$(cat $HUSKY_GIT_PARAMS)
 commit_name_regex="^(chore|docs|feat|fix|refactor|style|test)\/$jira_id:[[:space:]][[:alnum:]]+"
 merge_name_regex="^Merge[[:space:]]branch[[:space:]].*"
 commit_template="<type>/<jira-ticket-id>: <brief description>"
@@ -21,14 +21,10 @@ eg. \033[1;32m$commit_example\033[0m
 In the case of a merge, the name of commit should match the following template: \n\t\033[1;34m$merge_template\033[0m
 \nPlease rename your commit accordingly and try again.\n"
 
-# if ! [[ "$current_commit_name" =~ (${commit_name_regex})|(${merge_name_regex}) ]]
-# then
-#   echo -e $invalid_commit_message
-#   exit 1
-# fi
+if ! [[ "$current_commit_name" =~ (${commit_name_regex})|(${merge_name_regex}) ]]
+then
+  echo -e $invalid_commit_message
+  exit 1
+fi
 
-echo "hiii"
-echo $current_branch_name
-echo $current_commit_name
-
-exit 1
+exit 0

--- a/.husky/verify_commit_message
+++ b/.husky/verify_commit_message
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+current_branch_name=$(git rev-parse --abbrev-ref HEAD)
+jira_id_regex="MSSDK-[[:digit:]]+"
+jira_id=$(printf "$current_branch_name" | grep -Eo $jira_id_regex)
+
+current_commit_name=$(cat $1)
+commit_name_regex="^(chore|docs|feat|fix|refactor|style|test)\/$jira_id:[[:space:]][[:alnum:]]+"
+merge_name_regex="^Merge[[:space:]]branch[[:space:]].*"
+commit_template="<type>/<jira-ticket-id>: <brief description>"
+merge_template="Merge branch <rest of the description>"
+commit_example="fix/MSSDK-301: commit committed"
+winking_emoji="\xF0\x9F\x98\x89	"
+
+invalid_commit_message="\nThe commit name \033[1;31m$current_commit_name\033[0m does not adhere to the semantic naming convention. It should match this regular expression:
+\n\t\033[1;34m$commit_name_regex\033[0m
+\nProbs the below template will be more helpful $winking_emoji
+\n\t\033[1;34m$commit_template\033[0m
+eg. \033[1;32m$commit_example\033[0m
+\nThe <jira-ticket-id> should be consistent with the branch id.
+In the case of a merge, the name of commit should match the following template: \n\t\033[1;34m$merge_template\033[0m
+\nPlease rename your commit accordingly and try again.\n"
+
+# if ! [[ "$current_commit_name" =~ (${commit_name_regex})|(${merge_name_regex}) ]]
+# then
+#   echo -e $invalid_commit_message
+#   exit 1
+# fi
+
+echo "hiii"
+echo $current_branch_name
+echo $current_commit_name
+
+exit 1

--- a/.husky/verify_commit_message
+++ b/.husky/verify_commit_message
@@ -1,15 +1,17 @@
 #!/bin/bash
 
 current_branch_name=$(git rev-parse --abbrev-ref HEAD)
-jira_id_regex="MSSDK-[[:digit:]]+"
+jira_id_regex="MSSDK-([[:digit:]]|external)+"
 jira_id=$(printf "$current_branch_name" | grep -Eo $jira_id_regex)
 
 current_commit_name=$(cat $HUSKY_GIT_PARAMS)
 commit_name_regex="^(chore|docs|feat|fix|refactor|style|test)\/$jira_id:[[:space:]][[:alnum:]]+"
 merge_name_regex="^Merge[[:space:]]branch[[:space:]].*"
 commit_template="<type>/<jira-ticket-id>: <brief description>"
+external_commit_template="<type>/<MSSDK-external>: <brief-description>"
 merge_template="Merge branch <rest of the description>"
 commit_example="fix/MSSDK-301: commit committed"
+external_commit_example="feat/MSSDK-external: commit committed"
 winking_emoji="\xF0\x9F\x98\x89	"
 
 invalid_commit_message="\nThe commit name \033[1;31m$current_commit_name\033[0m does not adhere to the semantic naming convention. It should match this regular expression:
@@ -19,7 +21,10 @@ invalid_commit_message="\nThe commit name \033[1;31m$current_commit_name\033[0m 
 eg. \033[1;32m$commit_example\033[0m
 \nThe <jira-ticket-id> should be consistent with the branch id.
 In the case of a merge, the name of commit should match the following template: \n\t\033[1;34m$merge_template\033[0m
-\nPlease rename your commit accordingly and try again.\n"
+
+\n\nOh, and if you're an external contributor, use the following template: \n\t\033[1;35m$external_commit_template\033[0m e.g. \033[1;32m$external_commit_example\033[0m
+
+\n\nPlease rename your commit accordingly and try again.\n"
 
 if ! [[ "$current_commit_name" =~ (${commit_name_regex})|(${merge_name_regex}) ]]
 then

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": ".husky/verify_branch_name && lint-staged && npm run test"
+      "pre-commit": ".husky/verify_branch_name && lint-staged && npm run test",
+      "commit-msg": ".husky/verify_commit_message && lint-staged"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
### Description

To enhance the development process in the MSSDK team and check if commit messages meet the semantic standards, we need to add a relevant git hook.

### Updates

Added commit-msg hook to husky.

### Screenshots

![image](https://github.com/Cleeng/mediastore-sdk/assets/30701167/7a968221-7814-4888-a67a-ec5943886b8a)

After fix:
<img width="1093" alt="image" src="https://github.com/Cleeng/mediastore-sdk/assets/30701167/3171eaf2-05cb-4e79-8b80-7719c63de5b5">

<img width="1102" alt="image" src="https://github.com/Cleeng/mediastore-sdk/assets/30701167/6d3c0755-b7e4-40f0-834b-a78c0920bc27">





