### PR TITLE
fix/MSSDK-1511: calculate gross price only when tax rate is not 0

### DIFF
--- a/src/components/OfferCheckoutCard/OfferCheckoutCard.tsx
+++ b/src/components/OfferCheckoutCard/OfferCheckoutCard.tsx
@@ -51,14 +51,9 @@ const OfferCheckoutCard = () => {
   const currencySymbol = currencyFormat[currency];
   const isOfferFree =
     isTrialAvailable || (discount.applied && totalPrice === 0);
-  const grossPrice =
-    isOfferFree && taxRate !== 0
-      ? calculateGrossPriceForFreeOffer(
-          offerPrice,
-          taxRate,
-          customerPriceInclTax
-        )
-      : formatNumber(totalPrice);
+  const grossPrice = isOfferFree
+    ? calculateGrossPriceForFreeOffer(offerPrice, taxRate, customerPriceInclTax)
+    : formatNumber(totalPrice);
   const isTrialBadgeVisible = isTrialAvailable && discount.type === 'trial';
 
   const { t } = useTranslation();

--- a/src/components/OfferCheckoutCard/OfferCheckoutCard.tsx
+++ b/src/components/OfferCheckoutCard/OfferCheckoutCard.tsx
@@ -51,9 +51,14 @@ const OfferCheckoutCard = () => {
   const currencySymbol = currencyFormat[currency];
   const isOfferFree =
     isTrialAvailable || (discount.applied && totalPrice === 0);
-  const grossPrice = isOfferFree
-    ? calculateGrossPriceForFreeOffer(offerPrice, taxRate, customerPriceInclTax)
-    : formatNumber(totalPrice);
+  const grossPrice =
+    isOfferFree && taxRate !== 0
+      ? calculateGrossPriceForFreeOffer(
+          offerPrice,
+          taxRate,
+          customerPriceInclTax
+        )
+      : formatNumber(totalPrice);
   const isTrialBadgeVisible = isTrialAvailable && discount.type === 'trial';
 
   const { t } = useTranslation();

--- a/src/util/calculateGrossPriceForFreeOffer.js
+++ b/src/util/calculateGrossPriceForFreeOffer.js
@@ -3,6 +3,7 @@ const calculateGrossPriceForFreeOffer = (
   taxRate,
   customerPriceInclTax
 ) => {
+  if (taxRate === 0) return netPrice;
   const grossPrice = netPrice + taxRate * netPrice;
   const shouldRoundGrossPrice =
     customerPriceInclTax === Number(grossPrice.toFixed(2));


### PR DESCRIPTION
### Description

For some specific cases the wrong price rounding is applied in the checkout. In this fix, for cases where tax rate is 0 I return the net price as gross price.

### Updates

- return net price when tax rate is 0

### Screenshots
Added in the ticket. 

### Testing

### Additional Notes
