### PR TITLE
fix/MSSDK-1529: correct base price in the offer description

### DIFF
--- a/src/components/OfferCheckoutCard/OfferCheckoutCard.tsx
+++ b/src/components/OfferCheckoutCard/OfferCheckoutCard.tsx
@@ -121,11 +121,14 @@ const OfferCheckoutCard = () => {
 
   const generateCouponDescription = () => {
     const formattedTotalPrice = formatNumber(totalPrice);
-    const regularPrice = calculateGrossPriceForFreeOffer(
-      offerPrice,
-      taxRate,
-      customerPriceInclTax
-    );
+    const regularPrice =
+      period === 'season'
+        ? formatNumber(customerPriceInclTax)
+        : calculateGrossPriceForFreeOffer(
+            offerPrice,
+            taxRate,
+            customerPriceInclTax
+          );
     if (discountedPeriods === 1) {
       return t(
         `subscription-desc-coupon-${period}`,


### PR DESCRIPTION
### Description

Addressing a bug in the `OfferCheckoutCard`. If the user applied a coupon to the seasonal subscription with an ongoing promotional price, the copy incorrectly suggested that after the promotional period, they would still incur the discounted price, not the base price.

### Updates

- added a ternary operator to correctly display the base price for coupons applied to the seasonal offers


