### PR TITLE
feat/MSSDK-1550: Fix session endpoint call

### DIFF
--- a/src/containers/OfferContainer/OfferContainer.tsx
+++ b/src/containers/OfferContainer/OfferContainer.tsx
@@ -18,6 +18,7 @@ import {
   fetchCreateOrder,
   fetchGetOrder,
   fetchUpdateCoupon,
+  clearOrder,
   selectOrder
 } from 'redux/orderSlice';
 import eventDispatcher, {
@@ -86,8 +87,8 @@ const OfferContainer = ({
     setData('CLEENG_ORDER_ID', id);
   };
 
-  const reuseSavedOrder = (id: string, longOfferId: string) => {
-    dispatch(fetchGetOrder(id))
+  const reuseSavedOrder = async (id: string, longOfferId: string) => {
+    await dispatch(fetchGetOrder(id))
       .unwrap()
       .then(orderResponse => {
         const { customerId } = jwtDecode<{ customerId: number }>(
@@ -138,6 +139,12 @@ const OfferContainer = ({
   };
 
   useEffect(() => {
+    return () => {
+      dispatch(clearOrder());
+    };
+  }, []);
+
+  useEffect(() => {
     dispatch(
       initValues({
         offerId,
@@ -157,7 +164,7 @@ const OfferContainer = ({
       const orderId = getData('CLEENG_ORDER_ID');
 
       if (orderId) {
-        reuseSavedOrder(orderId, id);
+        await reuseSavedOrder(orderId, id);
       } else {
         await createOrderHandler(id);
       }
@@ -205,7 +212,6 @@ const OfferContainer = ({
       <ErrorPage type={errorMapping(errorMsg || offerError || orderError)} />
     );
   }
-
   if (isOrderLoading) {
     return (
       <StyledLoaderContainer>

--- a/src/redux/orderSlice.ts
+++ b/src/redux/orderSlice.ts
@@ -117,7 +117,9 @@ export const fetchGetOrder = createAsyncThunk<
 export const orderSlice = createSlice({
   name: 'order',
   initialState,
-  reducers: {},
+  reducers: {
+    clearOrder: () => initialState
+  },
   extraReducers: builder => {
     builder.addCase(fetchCreateOrder.pending, state => {
       state.loading = true;
@@ -140,7 +142,7 @@ export const orderSlice = createSlice({
       state.order = action.payload;
     });
     builder.addCase(fetchGetOrder.rejected, state => {
-      state.loading = false;
+      state.loading = true;
     });
     builder.addCase(fetchUpdateCoupon.pending, (state, action) => {
       state.isCouponLoading = true;
@@ -196,6 +198,7 @@ export const orderSlice = createSlice({
   }
 });
 
+export const { clearOrder } = orderSlice.actions;
 export const selectOrder = (state: RootState) => state.order;
 export const selectOnlyOrder = (state: RootState) => state.order.order;
 


### PR DESCRIPTION
### Description

During the process of checkout/purchase we are storing the orderId in the local storage. If the user after some time enter again the checkout/purchase we are showing that old order. There is a possibility that the order is invalid or expired and that is causing the 422 /sessions problem.
To remove that problem we made some changes to wait with the /sessions call as long as getOrder/createOrder is taking place. After succesful getting order or order creation the sessions request will be called. 

### Updates

- add async/await to make sure that we will be wainting for the end of the getOrder/createOrder
- because the unsuccesful getOrder is always followed by the createOrder we wont change the loading to false (just to make sure that, in that moment, the Offer component with the session call wont be rendered)
- clear order with the initialState in the orderSlice to make sure that we wont render the Offer component at the next Purchase/Checkout component render

### Screenshots

### Testing

### Additional Notes
