### PR TITLE
feat/MSSDK-1561: Remove the fallback language from i18next init

### DIFF
--- a/src/i18NextInit.js
+++ b/src/i18NextInit.js
@@ -16,6 +16,7 @@ i18n
     },
     nsSeparator: false,
     keySeparator: false,
+    fallbackLng: false,
     ns: ['translations'],
     defaultNS: 'translations',
     updateMissing: true,


### PR DESCRIPTION
### Description
Based on the i18next docs https://www.i18next.com/overview/configuration-options#languages-namespaces-resources we decided to remove the fallback language to remove a call for that one on the client side.


### Updates

Set a fallbackLng property to false

### Screenshots
Before:
<img width="770" alt="Screenshot 2023-09-27 at 11 47 12" src="https://github.com/Cleeng/mediastore-sdk/assets/19149811/bfcd4e49-cbed-4e93-af2f-ee3d0d8873b7">
After:
<img width="770" alt="Screenshot 2023-09-27 at 11 45 35" src="https://github.com/Cleeng/mediastore-sdk/assets/19149811/624bd7ed-1be8-42f9-8d5b-a70f525d282a">


### Testing

### Additional Notes
