### PR TITLE
fix/MSSDK-1560: Rerender payment component when totalPrice change

### DIFF
--- a/src/components/Adyen/Adyen.js
+++ b/src/components/Adyen/Adyen.js
@@ -452,7 +452,7 @@ const Adyen = ({
     if (isDropInPresent && discount?.applied) {
       recreateDropIn();
     }
-  }, [discount.applied, discount.type]);
+  }, [discount.applied, discount.type, totalPrice]);
 
   useEffect(() => {
     if (isDropInPresent) {


### PR DESCRIPTION
### Description

When the user enter the coupon code (100% for example) we are rendering the payment component because the discount was applied. After the coupon application if the user change the coupon code (50% for example) the Adyen component still renders the previous state (Confirm preauthorisation or the first price in the CTA button)

### Updates

Add `totalPrice` from order object to the `useEffect` dependencies array to re-render the Adyen component when the price change after couponCode reapplication

### Screenshots

### Testing

### Additional Notes
