### PR TITLE
fix/MSSDK-1618: Adyen throws error when trying to use Purchase or Checkout 

### DIFF
--- a/src/components/Adyen/Adyen.js
+++ b/src/components/Adyen/Adyen.js
@@ -355,15 +355,13 @@ const Adyen = ({
           return false;
         }
 
-        return true;
+        if (type === BANK_PAYMENT_METHODS) {
+          setShouldFadeOutStandardDropIn(true);
+        } else {
+          setShouldFadeOutBankDropIn(true);
+        }
 
-        // if (type === BANK_PAYMENT_METHODS) {
-        //   setShouldFadeOutStandardDropIn(true);
-        // } else {
-        //   setShouldFadeOutBankDropIn(true);
-        // }
-
-        // return onSubmit(state, component);
+        return onSubmit(state, component);
       },
       onActionHandled: () => {
         if (type === BANK_PAYMENT_METHODS) {


### PR DESCRIPTION
### Description

Fix of Adyen thrown error when trying to use Purchase or Checkout. It is related to checking legal payment checkbox before payment.


### Updates

`Component` object returned from Adyen `onSubmit` was used for checking it but now it can return `null`.  `State` object from Adyen cannot be used because we can use Visa card in Bancontact Card window, so it will return `type: scheme` and `brand: visa`. I will not know that it is Bancontact Card window.

Used `selectedPaymentMethod` from redux to check if Bancontact Card is opened.

