### PR TITLE
fix/MSSDK-1537: fix no payment method id when buying free offer

### DIFF
--- a/src/containers/OfferContainer/OfferContainer.tsx
+++ b/src/containers/OfferContainer/OfferContainer.tsx
@@ -106,7 +106,8 @@ const OfferContainer = ({
           !(
             orderResponse.offerId === longOfferId &&
             orderResponse.customerId === customerId
-          )
+          ) ||
+          !orderResponse?.paymentMethodId
         ) {
           removeData('CLEENG_ORDER_ID');
           createOrderHandler(longOfferId);


### PR DESCRIPTION
### Description

Issue:
Previously, when a free offer was purchased, the orderResponse object sometimes lacked a paymentMethodId. This absence caused an error in our system.

Solution:
The code has been updated to check for the paymentMethodId in the orderResponse. If paymentMethodId is falsy, an API call is made to retrieve this ID. This ensures that the process completes successfully even when the initial paymentMethodId is missing.

This modification ensures that orders for free offers are processed correctly without encountering errors related to missing paymentMethodId.