### PR TITLE
fix/MSSDK-1629: Replace the totalPrice changes by discountAmount

### DIFF
--- a/src/components/Adyen/Adyen.js
+++ b/src/components/Adyen/Adyen.js
@@ -44,7 +44,14 @@ const Adyen = ({
   const offer = useAppSelector(selectOnlyOffer);
   const termsUrl = useAppSelector(selectTermsUrl);
 
-  const { id: orderId, buyAsAGift, discount, totalPrice, offerId } = order;
+  const {
+    id: orderId,
+    buyAsAGift,
+    discount,
+    totalPrice,
+    offerId,
+    priceBreakdown: { discountAmount }
+  } = order;
 
   const {
     adyenConfiguration,
@@ -560,7 +567,7 @@ const Adyen = ({
     if (isDropInPresent && discount?.applied) {
       recreateDropIn();
     }
-  }, [discount.applied, discount.type, totalPrice]);
+  }, [discount.applied, discount.type, discountAmount]);
 
   useEffect(() => {
     if (isDropInPresent) {


### PR DESCRIPTION
### Description

There was a problem that Adyen dropin component was recreated after the changes of the paymentMethod (when paymentMethodFee was different -> totalPrice was different).

### Updates

- we replaced the totalPrice in the useEffect by the discountAmount so the Adyen dropin will be recreated only if the coupon change (this will change the discountAmount, we dont have info about the discount in % so we have to operate on the prices)

### Screenshots

### Testing

### Additional Notes
