### PR TITLE
feat/MSSDK-1633: When submitting payment form - error too subtle (difficult to spot)

### DIFF
--- a/src/components/Adyen/AdyenStyled.js
+++ b/src/components/Adyen/AdyenStyled.js
@@ -117,6 +117,9 @@ const AdyenStyled = styled.div.attrs(() => ({
     .msd__consents__frame {
       border-color: ${ErrorColor};
     }
+    .msd__consents__text {
+      color: ${ErrorColor};
+    }
   }
 
   .adyen-checkout__payment-method--standalone {

--- a/src/components/Payment/PayPal/PayPalStyled.ts
+++ b/src/components/Payment/PayPal/PayPalStyled.ts
@@ -47,5 +47,9 @@ export const CheckboxWrapperStyled = styled.div`
     .msd__consents__frame {
       border-color: ${ErrorColor};
     }
+
+    .msd__consents__text {
+      color: ${ErrorColor};
+    }
   }
 `;


### PR DESCRIPTION
### Description

When user enters a valid credit card but forget to submit the consent box, the error is too subtle.

### Updates

Changed consent text color when error is present

### Screenshots
<img width="678" alt="image" src="https://github.com/Cleeng/mediastore-sdk/assets/68298935/d2640a55-e525-4960-be23-4dfbe4d71d52">



