### PR TITLE
chore/MSSDK-1688: create ids as locators for testing

### DIFF
--- a/src/components/ErrorPage/ErrorPage.tsx
+++ b/src/components/ErrorPage/ErrorPage.tsx
@@ -68,7 +68,7 @@ const ErrorPage = ({
         <IconStyled>
           <Icon />
         </IconStyled>
-        <MessageStyled>
+        <MessageStyled id="offer-error-description">
           {error || t(typeParams.translationKey, typeParams.description)}
         </MessageStyled>
       </ErrorPageStyled>

--- a/src/components/UpdateSubscription/components/FreeExtension/FreeExtension.tsx
+++ b/src/components/UpdateSubscription/components/FreeExtension/FreeExtension.tsx
@@ -113,10 +113,10 @@ const FreeExtension = ({
         </TextWrapperStyled>
         <FreeExtensionCardStyled>
           <div>
-            <TextStyled>
+            <TextStyled id="free-extension-card-title">
               {t('free-extension.card-title', 'FREE EXTENSION')}
             </TextStyled>
-            <FreeExtensionCardPeriodStyled>
+            <FreeExtensionCardPeriodStyled id="free-extension-period">
               {renderPeriodTextElement()}
             </FreeExtensionCardPeriodStyled>
           </div>


### PR DESCRIPTION
### Description

The QA Team has requested that we add more IDs to the markup for locating elements when writing E2E tests.

### Updates

ID attributes have been added to `FreeExtension` and `ErrorPage` components.

### Screenshots

<img width="1141" alt="Screenshot 2024-01-15 at 16 15 58" src="https://github.com/Cleeng/mediastore-sdk/assets/30701167/39ece3d1-7be2-4fbc-90c8-b0f5be835e27">

<img width="1123" alt="Screenshot 2024-01-15 at 16 16 50" src="https://github.com/Cleeng/mediastore-sdk/assets/30701167/ea6d61ed-3957-45a1-9cae-83bfbb078354">

<img width="1348" alt="Screenshot 2024-01-15 at 16 22 12" src="https://github.com/Cleeng/mediastore-sdk/assets/30701167/3ee3a9ec-0195-4a93-bfe8-5154847559d9">

