### PR TITLE
feat/MSSDK-901: Add option to use custom reset password page in Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ yarn add @cleeng/mediastore-sdk styled-components
 ```javascript
 // import the following stylesheets in _app.js for Next.js projects, or your main App component for other use cases
 
-import "@adyen/adyen-web/dist/adyen.css";
-import "react-loading-skeleton/dist/skeleton.css";
+import '@adyen/adyen-web/dist/adyen.css';
+import 'react-loading-skeleton/dist/skeleton.css';
 ```
 
 #### 2. Configuration
@@ -98,20 +98,21 @@ Config functions save data to local storage (as `CLEENG_*` items). These data ar
 | `setEnable3DSRedirectFlow`      | -                                                            | Set to true to force 3DS redirect flow.                                                                                                                                 |
 | `setLanguage`                   | `language :string`                                           | Option to change language without reloading page                                                                                                                        |
 | `setTermsUrl`                   | `termsUrl :string`                                           | Option to Provide a URL for Terms & Conditions: This feature will display a link to them adjacent to the payment method.                                                |
+| `setResetUrl`                   | `resetUrl :string`                                           | Option to Provide a URL for custom password reset page. This URL will be sent in an email with additional parameters: `email`, `resetPasswordToken`, `publisherId`      |
 
 **Usage sample**
 
 ```javascript
-import { Config } from "@cleeng/mediastore-sdk";
+import { Config } from '@cleeng/mediastore-sdk';
 
-Config.setEnvironment("sandbox");
-Config.setPublisher("123456789");
-Config.setOffer("S123456789_US");
-Config.setVisibleAdyenPaymentMethods(["card", "applepay"]);
+Config.setEnvironment('sandbox');
+Config.setPublisher('123456789');
+Config.setOffer('S123456789_US');
+Config.setVisibleAdyenPaymentMethods(['card', 'applepay']);
 Config.setHidePayPal();
 Config.setEnable3DSRedirectFlow();
-Config.setLanguage("es");
-Config.setTermsUrl("https://your_terms_and_conditions-url.com");
+Config.setLanguage('es');
+Config.setTermsUrl('https://your_terms_and_conditions-url.com');
 ```
 
 #### Auth methods
@@ -209,15 +210,15 @@ If you prefer smaller components, you can use these to implement the exact featu
 **Config methods**
 
 ```javascript
-Config.setPublisherId("123456789"); // required
-Config.setMyAccountUrl("https://client-website.com/my-account"); // required for legal notes
+Config.setPublisherId('123456789'); // required
+Config.setMyAccountUrl('https://client-website.com/my-account'); // required for legal notes
 Config.setCheckoutPayPalUrls({
   // PayPal redirection URLs, required for PayPal payment
-  successUrl: "https://client-website.com/checkout/success",
-  cancelUrl: "https://client-website.com/checkout",
-  errorUrl: "https://client-website.com/checkout/error"
+  successUrl: 'https://client-website.com/checkout/success',
+  cancelUrl: 'https://client-website.com/checkout',
+  errorUrl: 'https://client-website.com/checkout/error'
 });
-Config.setVisibleAdyenPaymentMethods(["card", "googlepay"]); // array of presented payment methods
+Config.setVisibleAdyenPaymentMethods(['card', 'googlepay']); // array of presented payment methods
 ```
 
 **Props**
@@ -231,17 +232,17 @@ Config.setVisibleAdyenPaymentMethods(["card", "googlepay"]); // array of present
 **Usage**
 
 ```javascript
-import { Checkout, store } from "@cleeng/mediastore-sdk";
-import { Provider } from "react-redux";
-import adyenConfiguration from "./adyenConfiguration";
+import { Checkout, store } from '@cleeng/mediastore-sdk';
+import { Provider } from 'react-redux';
+import adyenConfiguration from './adyenConfiguration';
 
 <Provider store={store}>
   <Checkout
-    onSuccess={() => console.log("success")}
-    offerId={"S531234647_PL"}
+    onSuccess={() => console.log('success')}
+    offerId={'S531234647_PL'}
     adyenConfiguration={adyenConfiguration}
     resetPasswordCallback={() =>
-      console.log("redirect customer to the login page")
+      console.log('redirect customer to the login page')
     }
   />
 </Provider>;
@@ -261,16 +262,16 @@ import adyenConfiguration from "./adyenConfiguration";
 **Config methods**
 
 ```javascript
-Config.setPublisher("111111111"); // required when JWT or refreshToken are not provided
-Config.setJWT("xxx"); // optional, when Login should be skipped
-Config.setRefreshToken("yyy"); // optional
+Config.setPublisher('111111111'); // required when JWT or refreshToken are not provided
+Config.setJWT('xxx'); // optional, when Login should be skipped
+Config.setRefreshToken('yyy'); // optional
 Config.setMyAccountPayPalUrls({
   // PayPal redirection URLs, required for update PayPal payment details
-  successUrl: "https://client-website.com/my-account/payment-info",
-  cancelUrl: "https://client-website.com/my-account/payment-info",
-  errorUrl: "https://client-website.com/my-account/paypal-error"
+  successUrl: 'https://client-website.com/my-account/payment-info',
+  cancelUrl: 'https://client-website.com/my-account/payment-info',
+  errorUrl: 'https://client-website.com/my-account/paypal-error'
 });
-Config.setVisibleAdyenPaymentMethods(["card", "googlepay"]); // array of presented payment methods
+Config.setVisibleAdyenPaymentMethods(['card', 'googlepay']); // array of presented payment methods
 ```
 
 **Props**
@@ -284,18 +285,18 @@ Config.setVisibleAdyenPaymentMethods(["card", "googlepay"]); // array of present
 **Usage sample**
 
 ```javascript
-import { MyAccount, store } from "@cleeng/mediastore-sdk";
-import { Provider } from "react-redux";
-import adyenConfiguration from "./adyenConfiguration";
+import { MyAccount, store } from '@cleeng/mediastore-sdk';
+import { Provider } from 'react-redux';
+import adyenConfiguration from './adyenConfiguration';
 
 const customCancellationReasons = [
   {
-    value: "Poor customer support",
-    key: "custom-cancellation-reason.poor-customer-support"
+    value: 'Poor customer support',
+    key: 'custom-cancellation-reason.poor-customer-support'
   },
   {
-    value: "Switch to a different service",
-    key: "custom-cancellation-reason.switch-to-different-service"
+    value: 'Switch to a different service',
+    key: 'custom-cancellation-reason.switch-to-different-service'
   }
 ];
 
@@ -318,7 +319,7 @@ const customCancellationReasons = [
 **Config methods**
 
 ```javascript
-Config.setPublisher("111111111"); // required
+Config.setPublisher('111111111'); // required
 ```
 
 **Props**
@@ -355,8 +356,8 @@ Config.setPublisher("111111111");
 **Config methods**
 
 ```javascript
-Config.setPublisher("111111111"); // required
-Config.setOffer("S123456789_US"); // optional, can be used as a replacement of setPublisher
+Config.setPublisher('111111111'); // required
+Config.setOffer('S123456789_US'); // optional, can be used as a replacement of setPublisher
 ```
 
 **Props**
@@ -370,12 +371,12 @@ Config.setOffer("S123456789_US"); // optional, can be used as a replacement of s
 **Usage sample**
 
 ```javascript
-Config.setPublisher("111111111");
+Config.setPublisher('111111111');
 
 <Login
-  onSuccess={() => console.log("success")}
-  onRegisterClick={() => console.log("register button clicked")}
-  onPasswordResetClick={() => console.log("password reset button clicked")}
+  onSuccess={() => console.log('success')}
+  onRegisterClick={() => console.log('register button clicked')}
+  onPasswordResetClick={() => console.log('password reset button clicked')}
 />;
 ```
 
@@ -388,7 +389,7 @@ Config.setPublisher("111111111");
 **Config methods**
 
 ```javascript
-Config.setPublisher("111111111"); // required
+Config.setPublisher('111111111'); // required
 ```
 
 **Props**
@@ -398,7 +399,7 @@ Config.setPublisher("111111111"); // required
 **Usage sample**
 
 ```javascript
-<PasswordReset onSuccess={() => console.log("success")} />
+<PasswordReset onSuccess={() => console.log('success')} />
 ```
 
 <div align="right">[ <a href="#table-of-contents">↑ Back to top ↑</a> ]</div>
@@ -417,30 +418,30 @@ Config.setPublisher("111111111"); // required
 **Config methods**
 
 ```javascript
-Config.setJWT("xxx"); // required conditionally, if Login or Register component is not used
-Config.setRefreshToken("yyy"); // optional
-Config.setMyAccountUrl("https://client-website.com/my-account"); // required for legal notes
+Config.setJWT('xxx'); // required conditionally, if Login or Register component is not used
+Config.setRefreshToken('yyy'); // optional
+Config.setMyAccountUrl('https://client-website.com/my-account'); // required for legal notes
 Config.setCheckoutPayPalUrls({
   // PayPal redirection URLs, required for PayPal payment
-  successUrl: "https://client-website.com/my-account",
-  cancelUrl: "https://client-website.com/my-account",
-  errorUrl: "https://client-website.com/my-account/paypal-error"
+  successUrl: 'https://client-website.com/my-account',
+  cancelUrl: 'https://client-website.com/my-account',
+  errorUrl: 'https://client-website.com/my-account/paypal-error'
 });
-Config.setVisibleAdyenPaymentMethods(["card", "googlepay"]); // array of presented payment methods
+Config.setVisibleAdyenPaymentMethods(['card', 'googlepay']); // array of presented payment methods
 ```
 
 **Usage sample**
 
 ```javascript
-import { Purchase, Config, store } from "@cleeng/mediastore-sdk";
-import { Provider } from "react-redux";
-import adyenConfiguration from "./adyenConfiguration";
+import { Purchase, Config, store } from '@cleeng/mediastore-sdk';
+import { Provider } from 'react-redux';
+import adyenConfiguration from './adyenConfiguration';
 
 <Provider store={store}>
   <Purchase
     offerId="S538257415_PL"
     adyenConfiguration={adyenConfiguration}
-    onSuccess={() => console.log("success")}
+    onSuccess={() => console.log('success')}
   />
 </Provider>;
 ```
@@ -459,15 +460,15 @@ import adyenConfiguration from "./adyenConfiguration";
 **Config methods**
 
 ```javascript
-Config.setJWT("xxx"); // required
-Config.setRefreshToken("yyy"); // optional
+Config.setJWT('xxx'); // required
+Config.setRefreshToken('yyy'); // optional
 ```
 
 **Usage sample**
 
 ```javascript
-import { Subscriptions, store } from "@cleeng/mediastore-sdk";
-import { Provider } from "react-redux";
+import { Subscriptions, store } from '@cleeng/mediastore-sdk';
+import { Provider } from 'react-redux';
 
 <Provider store={store}>
   <Subscriptions skipAvailableDowngradesStep />
@@ -483,8 +484,8 @@ This component shows a list of available switches for a given subscription passe
 **Config methods**
 
 ```javascript
-Config.setJWT("xxx"); // required
-Config.setRefreshToken("yyy"); // optional
+Config.setJWT('xxx'); // required
+Config.setRefreshToken('yyy'); // optional
 ```
 
 **Props**
@@ -501,18 +502,18 @@ If you are providing the `toOfferId` prop you need to validate if this switch is
 **Usage sample**
 
 ```javascript
-Config.setJWT("xxx"); // required
-Config.setRefreshToken("yyy"); // optional
+Config.setJWT('xxx'); // required
+Config.setRefreshToken('yyy'); // optional
 ```
 
 **Usage sample**
 
 ```javascript
-import { SubscriptionSwitches, store } from "@cleeng/mediastore-sdk";
-import { Provider } from "react-redux";
+import { SubscriptionSwitches, store } from '@cleeng/mediastore-sdk';
+import { Provider } from 'react-redux';
 
 <Provider store={store}>
-  <SubscriptionSwitches offerId={"S538257415_PL"} />
+  <SubscriptionSwitches offerId={'S538257415_PL'} />
 </Provider>;
 ```
 
@@ -528,8 +529,8 @@ import { Provider } from "react-redux";
 **Config methods**
 
 ```javascript
-Config.setJWT("xxx"); // required
-Config.setRefreshToken("yyy"); // optional
+Config.setJWT('xxx'); // required
+Config.setRefreshToken('yyy'); // optional
 ```
 
 **Props**
@@ -542,17 +543,17 @@ Config.setRefreshToken("yyy"); // optional
 **Usage sample**
 
 ```javascript
-import { PlanDetails } from "@cleeng/mediastore-sdk";
-import { Provider } from "react-redux";
+import { PlanDetails } from '@cleeng/mediastore-sdk';
+import { Provider } from 'react-redux';
 
 const customCancellationReasons = [
   {
-    value: "Poor customer support",
-    key: "custom-cancellation-reason.poor-customer-support"
+    value: 'Poor customer support',
+    key: 'custom-cancellation-reason.poor-customer-support'
   },
   {
-    value: "Switch to a different service",
-    key: "custom-cancellation-reason.switch-to-different-service"
+    value: 'Switch to a different service',
+    key: 'custom-cancellation-reason.switch-to-different-service'
   }
 ];
 
@@ -577,15 +578,15 @@ PaymentInfo is a component that contains all information about customer payments
 **Config methods**
 
 ```javascript
-Config.setJWT("xxx"); // required
-Config.setRefreshToken("yyy"); // optional
+Config.setJWT('xxx'); // required
+Config.setRefreshToken('yyy'); // optional
 Config.setMyAccountPayPalUrls({
   // PayPal redirection URLs, required for update PayPal payment details
-  successUrl: "https://client-website.com/my-account/payment-info",
-  cancelUrl: "https://client-website.com/my-account/payment-info",
-  errorUrl: "https://client-website.com/my-account/paypal-error"
+  successUrl: 'https://client-website.com/my-account/payment-info',
+  cancelUrl: 'https://client-website.com/my-account/payment-info',
+  errorUrl: 'https://client-website.com/my-account/paypal-error'
 });
-Config.setVisibleAdyenPaymentMethods(["card", "googlepay"]); // array of presented payment methods
+Config.setVisibleAdyenPaymentMethods(['card', 'googlepay']); // array of presented payment methods
 ```
 
 **Props**
@@ -596,9 +597,9 @@ Config.setVisibleAdyenPaymentMethods(["card", "googlepay"]); // array of present
 **Usage sample**
 
 ```javascript
-import { PaymentInfo, store } from "@cleeng/mediastore-sdk";
-import { Provider } from "react-redux";
-import adyenConfiguration from "./adyenConfiguration";
+import { PaymentInfo, store } from '@cleeng/mediastore-sdk';
+import { Provider } from 'react-redux';
+import adyenConfiguration from './adyenConfiguration';
 
 <Provider store={store}>
   <PaymentInfo
@@ -617,15 +618,15 @@ import adyenConfiguration from "./adyenConfiguration";
 **Config methods**
 
 ```javascript
-Config.setJWT("xxx"); // required
-Config.setRefreshToken("yyy"); // optional
+Config.setJWT('xxx'); // required
+Config.setRefreshToken('yyy'); // optional
 ```
 
 **Usage sample**
 
 ```javascript
-import { TransactionList, store } from "@cleeng/mediastore-sdk";
-import { Provider } from "react-redux";
+import { TransactionList, store } from '@cleeng/mediastore-sdk';
+import { Provider } from 'react-redux';
 
 <Provider store={store}>
   <TransactionList />
@@ -643,8 +644,8 @@ Customers will also be able to reset their password or update consents from the 
 **Config methods**
 
 ```javascript
-Config.setJWT("xxx"); // required
-Config.setRefreshToken("yyy"); // optional
+Config.setJWT('xxx'); // required
+Config.setRefreshToken('yyy'); // optional
 ```
 
 **Props**
@@ -654,8 +655,8 @@ Config.setRefreshToken("yyy"); // optional
 **Usage sample**
 
 ```javascript
-import { UpdateProfile, store } from "@cleeng/mediastore-sdk";
-import { Provider } from "react-redux";
+import { UpdateProfile, store } from '@cleeng/mediastore-sdk';
+import { Provider } from 'react-redux';
 
 <Provider store={store}>
   <UpdateProfile displayGracePeriodError />
@@ -671,8 +672,8 @@ import { Provider } from "react-redux";
 **Config methods**
 
 ```javascript
-Config.setJWT("xxx"); // required
-Config.setRefreshToken("yyy"); // optional
+Config.setJWT('xxx'); // required
+Config.setRefreshToken('yyy'); // optional
 ```
 
 **Props**
@@ -680,7 +681,7 @@ Config.setRefreshToken("yyy"); // optional
 - `onSuccess` \* - callback function called after successful form submission, or immediately if there are no available consents fields to update
 
 ```javascript
-<CheckoutConsents onSuccess={() => console.log("success")} />
+<CheckoutConsents onSuccess={() => console.log('success')} />
 ```
 
 <div align="right">[ <a href="#table-of-contents">↑ Back to top ↑</a> ]</div>
@@ -694,8 +695,8 @@ If there are any required, and unanswered, capture questions, this component wil
 **Config methods**
 
 ```javascript
-Config.setJWT("xxx"); // required
-Config.setRefreshToken("yyy"); // optional
+Config.setJWT('xxx'); // required
+Config.setRefreshToken('yyy'); // optional
 ```
 
 **Props**
@@ -705,7 +706,7 @@ Config.setRefreshToken("yyy"); // optional
 **Usage sample**
 
 ```javascript
-<Capture onSuccess={() => console.log("success")} />
+<Capture onSuccess={() => console.log('success')} />
 ```
 
 <div align="right">[ <a href="#table-of-contents">↑ Back to top ↑</a> ]</div>
@@ -721,8 +722,8 @@ If user is not logged in, `MSSDK:auth-failed` event will be emitted.
 **Config methods**
 
 ```javascript
-Config.setJWT("xxx"); // required
-Config.setRefreshToken("yyy"); // optional
+Config.setJWT('xxx'); // required
+Config.setRefreshToken('yyy'); // optional
 ```
 
 **Props**
@@ -733,13 +734,13 @@ Config.setRefreshToken("yyy"); // optional
 **Usage sample**
 
 ```javascript
-import { RedeemGift, store } from "@cleeng/mediastore-sdk";
-import { Provider } from "react-redux";
+import { RedeemGift, store } from '@cleeng/mediastore-sdk';
+import { Provider } from 'react-redux';
 
 <Provider store={store}>
   <RedeemGift
-    onBackClick={() => console.log("Back to the Checkout")}
-    onSuccess={() => console.log("success")}
+    onBackClick={() => console.log('Back to the Checkout')}
+    onSuccess={() => console.log('success')}
   />
 </Provider>;
 ```
@@ -753,7 +754,7 @@ import { Provider } from "react-redux";
 If your application doesn't have a font specified, you can apply the default font (OpenSans) for all MSSDK components by:
 
 ```javascript
-import "@cleeng/mediastore-sdk/dist/styles/msdFont.css";
+import '@cleeng/mediastore-sdk/dist/styles/msdFont.css';
 ```
 
 #### Styling options
@@ -771,14 +772,14 @@ Here is an example how to do it:
 
 ```javascript
 Config.setTheme({
-  fontColor: "#ffffff",
-  backgroundColor: "#292525",
-  cardColor: "#675d5d",
-  successColor: "#435dc5",
-  primaryColor: "#435dc5",
-  loaderColor: "#cccccc",
-  errorColor: "red",
-  logoUrl: "link-to-the-logo"
+  fontColor: '#ffffff',
+  backgroundColor: '#292525',
+  cardColor: '#675d5d',
+  successColor: '#435dc5',
+  primaryColor: '#435dc5',
+  loaderColor: '#cccccc',
+  errorColor: 'red',
+  logoUrl: 'link-to-the-logo'
 });
 ```
 
@@ -795,7 +796,7 @@ Here is a simple example how styles can be added:
   border-bottom: none;
 }
 .msd__header div {
-  background-image: url("./logo\ —\ white.png");
+  background-image: url('./logo\ —\ white.png');
   background-size: auto 60%;
 }
 .msd__auth-wrapper {
@@ -818,11 +819,11 @@ Components provide a way of communication with your application. Components send
 To react to events, add an event listener, like in the sample below:
 
 ```javascript
-window.addEventListener("MSSDK:Purchase-loaded", () =>
-  console.log("Purchase component loaded")
+window.addEventListener('MSSDK:Purchase-loaded', () =>
+  console.log('Purchase component loaded')
 );
-window.addEventListener("MSSDK:redeem-coupon-failed", evt =>
-  console.log("Customer tried to apply coupon:", evt.detail.coupon)
+window.addEventListener('MSSDK:redeem-coupon-failed', evt =>
+  console.log('Customer tried to apply coupon:', evt.detail.coupon)
 );
 ```
 
@@ -954,13 +955,13 @@ Below, you can find a short guide on how to implement custom copies or translati
 4. To enable a new language, you have to add `?lng=es` at the end of your url or set an entry in your local storage.
 
 ```javascript
-localStorage.setItem("i18nextLng", "es");
+localStorage.setItem('i18nextLng', 'es');
 ```
 
 5. To change language without reloading the page you can use Config method, it will automatically change i18nextLng in local storage.
 
 ```javascript
-Config.setLanguage("es");
+Config.setLanguage('es');
 ```
 
 Some of the languages require different directions than the default left-to-right. MediaStore SDK components library support right-to-left direction which can be enabled by adding the `dir` attribute to `html` tag.

--- a/src/api/Auth/resetPassword.js
+++ b/src/api/Auth/resetPassword.js
@@ -1,13 +1,17 @@
 import { fetchWithHeaders } from 'util/fetchHelper';
 import getApiURL from 'util/environmentHelper';
 
-const resetPassword = async (customerEmail, publisherId = '') => {
+const resetPassword = async (customerEmail, publisherId = '', resetUrl) => {
   const API_URL = getApiURL();
   const url = `${API_URL}/customers/passwords`;
   try {
     const res = await fetchWithHeaders(url, {
       method: 'PUT',
-      body: JSON.stringify({ publisherId, customerEmail })
+      body: JSON.stringify({
+        publisherId,
+        customerEmail,
+        resetUrl
+      })
     });
     const json = await res.json();
     if (json.message) {

--- a/src/components/EditPassword/EditPassword.tsx
+++ b/src/components/EditPassword/EditPassword.tsx
@@ -1,4 +1,6 @@
 import { useState } from 'react';
+import { useAppSelector } from 'redux/store';
+import { selectPublisherConfig } from 'redux/publisherConfigSlice';
 import { t } from 'i18next';
 import jwtDecode from 'jwt-decode';
 import { getData } from 'util/appConfigHelper';
@@ -26,6 +28,8 @@ const EditPassword = ({
   const [isLoading, setIsLoading] = useState(false);
   const [isError, setIsError] = useState(false);
 
+  const { resetUrl } = useAppSelector(selectPublisherConfig);
+
   const renderNextStep = () => {
     setStep(prevStep => prevStep + 1);
   };
@@ -44,7 +48,12 @@ const EditPassword = ({
       const { publisherId } = jwtDecode(getData('CLEENG_AUTH_TOKEN')) as {
         publisherId: string;
       };
-      const response = await resetPassword(customerEmail, String(publisherId));
+
+      const response = await resetPassword(
+        customerEmail,
+        String(publisherId),
+        resetUrl
+      );
       if (!response.errors.length) {
         renderNextStep();
         setIsLoading(false);

--- a/src/components/PasswordReset/PasswordReset.js
+++ b/src/components/PasswordReset/PasswordReset.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import store from 'redux/store';
 import PropTypes from 'prop-types';
 import { withTranslation } from 'react-i18next';
 import EmailInput from 'components/EmailInput';
@@ -33,13 +34,19 @@ class PasswordReset extends Component {
   onSubmit = async e => {
     e.preventDefault();
     const publisherId = getData('CLEENG_PUBLISHER_ID');
+
     const { value } = this.state;
     const { onSuccess, t } = this.props;
+
+    const {
+      publisherConfig: { resetUrl }
+    } = store.getState();
+
     if (this.validateFields()) {
       this.setState({
         processing: true
       });
-      const response = await resetPassword(value, publisherId);
+      const response = await resetPassword(value, publisherId, resetUrl);
       if (response.errors.length) {
         if (response.status === 429) {
           this.setState({

--- a/src/redux/publisherConfigSlice.ts
+++ b/src/redux/publisherConfigSlice.ts
@@ -12,6 +12,7 @@ export const initialState: PublisherConfigInitialState = {
   adyenConfiguration: null,
   displayGracePeriodError: false,
   termsUrl: '',
+  resetUrl: '',
   enable3DSRedirectFlow: false
 };
 

--- a/src/redux/types/publisherConfigSlice.types.ts
+++ b/src/redux/types/publisherConfigSlice.types.ts
@@ -56,6 +56,7 @@ export type PublisherConfigInitialState = {
   adyenConfiguration: null | AdyenConfiguration;
   displayGracePeriodError: boolean;
   termsUrl: string;
+  resetUrl: string;
   enable3DSRedirectFlow: boolean;
 };
 

--- a/src/util/appConfigHelper.js
+++ b/src/util/appConfigHelper.js
@@ -133,6 +133,14 @@ export const setTermsUrl = termsUrl => {
   return false;
 };
 
+export const setResetUrl = resetUrl => {
+  if (resetUrl) {
+    store.dispatch(initPublisherConfig({ resetUrl }));
+    return true;
+  }
+  return false;
+};
+
 export const setTheme = theme => {
   const themeString = JSON.stringify(theme);
   if (theme) {
@@ -216,6 +224,7 @@ export default {
   setJWT,
   setRefreshToken,
   setTermsUrl,
+  setResetUrl,
   setHidePayPal,
   setVisibleAdyenPaymentMethods,
   setHiddenPaymentMethods,


### PR DESCRIPTION
### Description
Currently, when customer tries to change the password through the MSSDK Components, he/she is redirected from the email to the Cleeng reset password page.
We could add an option to MSSDK components, so the publisher will be able to create his own reset password page.


### Updates
Added `Config.setResetUrl()` method to set custom reset password url. This url will be sent to user's email with additional parameters.
