### PR TITLE
fix/MSSDK-1512: grossPrice calculation does not cover edge-cases properly 

### DIFF
--- a/src/util/calculateGrossPriceForFreeOffer.ts
+++ b/src/util/calculateGrossPriceForFreeOffer.ts
@@ -12,7 +12,7 @@ const calculateGrossPriceForFreeOffer = (
     return grossPrice.toFixed(2);
   }
   // required to handle price edge cases
-  return (Math.trunc(grossPrice * 100) / 100).toFixed(2);
+  return (Math.trunc(Math.ceil(grossPrice * 100)) / 100).toFixed(2);
 };
 
 export default calculateGrossPriceForFreeOffer;

--- a/src/util/calculateTaxValueForFreeOffer.ts
+++ b/src/util/calculateTaxValueForFreeOffer.ts
@@ -11,7 +11,7 @@ const calculateTaxValueForFreeOffer = (
     return taxValue.toFixed(2);
   }
   // required to handle tax edge cases
-  return (Math.trunc(taxValue * 100) / 100).toFixed(2);
+  return (Math.trunc(Math.ceil(taxValue * 100)) / 100).toFixed(2);
 };
 
 export default calculateTaxValueForFreeOffer;


### PR DESCRIPTION
### Description
`grossPrice` does not get a proper formatting - displayed price is equal to EUR 9.98 when it should be 9.99

### Updates
used `Math.ceil()` function to round price up



