### PR TITLE
feat/MSSDK-1675: Add option to hide redeem gift button in Checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Config.setVisibleAdyenPaymentMethods(['card', 'googlepay']); // array of present
 - `resetPasswordCallback` - function called after a successful reset password request, when customer clicks 'Go back to the login page'
 - `adyenConfiguration` - an optional parameter that can be used to customize look and feel of the Adyen payment in purchase section. Read more information about Adyen configuration [here](#adyen-configuration).
 - `couponCode` - coupon code that should be automatically applied
+- `hideRedeemButton` - an optional parameter that can be used to hide 'Redeem here' button
 
 **Usage**
 

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ import adyenConfiguration from './adyenConfiguration';
     resetPasswordCallback={() =>
       console.log('redirect customer to the login page')
     }
+    hideRedeemButton
   />
 </Provider>;
 ```

--- a/src/components/Checkout/Checkout.js
+++ b/src/components/Checkout/Checkout.js
@@ -89,7 +89,8 @@ class Checkout extends Component {
       couponCode,
       onSuccess,
       offerId,
-      resetPasswordCallback
+      resetPasswordCallback,
+      hideRedeemButton
     } = this.props;
 
     switch (currentStep) {
@@ -134,6 +135,7 @@ class Checkout extends Component {
             onRedeemClick={() =>
               this.goToStep(CheckoutSteps.REDEEM_GIFT.stepNumber)
             }
+            hideRedeemButton={hideRedeemButton}
           />
         );
       case 5:
@@ -169,20 +171,22 @@ class Checkout extends Component {
 }
 
 Checkout.propTypes = {
+  adyenConfiguration: PropTypes.objectOf(PropTypes.any),
   couponCode: PropTypes.string,
+  hideRedeemButton: PropTypes.bool,
+  initValues: PropTypes.func.isRequired,
   offerId: PropTypes.string,
   onSuccess: PropTypes.func,
-  resetPasswordCallback: PropTypes.func,
-  adyenConfiguration: PropTypes.objectOf(PropTypes.any),
-  initValues: PropTypes.func.isRequired
+  resetPasswordCallback: PropTypes.func
 };
 
 Checkout.defaultProps = {
+  adyenConfiguration: null,
   couponCode: null,
+  hideRedeemButton: false,
   offerId: null,
   onSuccess: () => null,
-  resetPasswordCallback: () => null,
-  adyenConfiguration: null
+  resetPasswordCallback: () => null
 };
 
 export const mapDispatchToProps = dispatch => ({

--- a/src/components/CheckoutPriceBox/CheckoutPriceBox.js
+++ b/src/components/CheckoutPriceBox/CheckoutPriceBox.js
@@ -23,7 +23,7 @@ import {
   StyledRedeemButton
 } from './CheckoutPriceBoxStyled';
 
-const CheckoutPriceBox = ({ isCheckout, onRedeemClick }) => {
+const CheckoutPriceBox = ({ hideRedeemButton, isCheckout, onRedeemClick }) => {
   const { customerPriceInclTax } = useAppSelector(selectOnlyOffer);
   const {
     priceBreakdown: {
@@ -60,6 +60,8 @@ const CheckoutPriceBox = ({ isCheckout, onRedeemClick }) => {
 
     return t(`coupon-note-applied`, 'Promotional Pricing applied!');
   };
+
+  const shouldShowRedeemButton = !hideRedeemButton && isCheckout;
 
   return (
     <StyledPriceBoxWrapper>
@@ -151,7 +153,7 @@ const CheckoutPriceBox = ({ isCheckout, onRedeemClick }) => {
             </StyledTotalOfferPrice>
           </StyledTotalWrapper>
         </StyledPriceWrapper>
-        {isCheckout && (
+        {shouldShowRedeemButton && (
           <StyledRedeemButton>
             <span>
               {t('checkout-price-box.gift-code-label', 'Have a gift code?')}
@@ -167,13 +169,15 @@ const CheckoutPriceBox = ({ isCheckout, onRedeemClick }) => {
 };
 
 CheckoutPriceBox.propTypes = {
+  hideRedeemButton: PropTypes.bool,
   isCheckout: PropTypes.bool,
   onRedeemClick: PropTypes.func
 };
 
 CheckoutPriceBox.defaultProps = {
-  onRedeemClick: () => null,
-  isCheckout: false
+  hideRedeemButton: false,
+  isCheckout: false,
+  onRedeemClick: () => null
 };
 
 export { CheckoutPriceBox as PureCheckoutPriceBox };

--- a/src/components/Offer/Offer.tsx
+++ b/src/components/Offer/Offer.tsx
@@ -25,7 +25,8 @@ const Offer = ({
   isCheckout = false,
   onCouponSubmit,
   onPaymentComplete,
-  onRedeemClick
+  onRedeemClick,
+  hideRedeemButton
 }: OfferProps) => {
   const { t } = useTranslation();
   const [coupon, setCoupon] = useState('');
@@ -82,6 +83,7 @@ const Offer = ({
             </StyledOfferCouponWrapper>
           </StyledOfferDetailsAndCoupon>
           <CheckoutPriceBox
+            hideRedeemButton={hideRedeemButton}
             isCheckout={isCheckout}
             onRedeemClick={onRedeemClick}
           />

--- a/src/components/Offer/Offer.types.ts
+++ b/src/components/Offer/Offer.types.ts
@@ -1,4 +1,5 @@
 export type OfferProps = {
+  hideRedeemButton: boolean;
   isCheckout?: boolean;
   onCouponSubmit: (couponCode: string) => void;
   onPaymentComplete: () => void;

--- a/src/containers/OfferContainer/OfferContainer.tsx
+++ b/src/containers/OfferContainer/OfferContainer.tsx
@@ -46,7 +46,8 @@ const OfferContainer = ({
   isCheckout = false,
   offerId: offerIdProp,
   onSuccess,
-  onRedeemClick
+  onRedeemClick,
+  hideRedeemButton
 }: OfferContainerProps) => {
   const [errorMsg, setErrorMsg] = useState<string>();
 
@@ -268,6 +269,7 @@ const OfferContainer = ({
 
   return (
     <Offer
+      hideRedeemButton={hideRedeemButton}
       isCheckout={isCheckout}
       onCouponSubmit={onCouponSubmit}
       onPaymentComplete={onSuccess}

--- a/src/containers/OfferContainer/OfferContainer.types.ts
+++ b/src/containers/OfferContainer/OfferContainer.types.ts
@@ -3,6 +3,7 @@ import { AdyenConfiguration } from 'redux/types/publisherConfigSlice.types';
 export type OfferContainerProps = {
   adyenConfiguration?: AdyenConfiguration;
   couponCode?: string;
+  hideRedeemButton: boolean;
   isCheckout?: boolean;
   offerId: string;
   onSuccess: (...args: unknown[]) => void;


### PR DESCRIPTION
### Description

Some publishers are not using gifting feature and would like to hide Redeem here button from in Checkout. Add prop to make it possible.

### Updates

Added `hideRedeemButton` prop in `Checkout `component
