### PR TITLE
fix/MSSDK-1670: Capture after register in Checkout component does not show error for names fields

### DIFF
--- a/src/components/Capture/CaptureForm/CaptureForm.js
+++ b/src/components/Capture/CaptureForm/CaptureForm.js
@@ -104,14 +104,20 @@ const CaptureForm = ({ settings, onSuccess }) => {
       firstName.setError(
         t('captureform.error.first-name', 'First Name is required')
       );
+      setIsError(true);
     }
 
     if (inputName === 'lastName' && !lastName.value) {
       lastName.setError(
         t('captureform.error.last-name', 'Last Name is required')
       );
+      setIsError(true);
     }
-    if (!firstName.value || !lastName.value) setIsError(true);
+
+    if (!inputName) {
+      validateNames('firstName');
+      validateNames('lastName');
+    }
   };
 
   const validateAddress = () => {


### PR DESCRIPTION
### Description

 Capture after register in Checkout component does not show error for names fields
 
 ### Screenshots
 
<img width="637" alt="image" src="https://github.com/Cleeng/mediastore-sdk/assets/68298935/7f2b5450-4186-4cfb-b804-362d488ebfa5">


