### PR TITLE
fix/MSSDK-1712: Edit the condition to remove order overwriting

### DIFF
--- a/src/containers/OfferContainer/OfferContainer.tsx
+++ b/src/containers/OfferContainer/OfferContainer.tsx
@@ -56,14 +56,14 @@ const OfferContainer = ({
 
   const dispatch = useAppDispatch();
 
-  const { offerId: offerIdStore, adyenConfiguration: adyenConfigurationStore } =
-    useAppSelector(selectPublisherConfig);
-
   const {
-    order,
-    loading: isOrderLoading,
-    error: orderError
-  } = useAppSelector(selectOrder);
+    offerId: offerIdStore,
+    adyenConfiguration: adyenConfigurationStore
+  } = useAppSelector(selectPublisherConfig);
+
+  const { order, loading: isOrderLoading, error: orderError } = useAppSelector(
+    selectOrder
+  );
 
   const { error: offerError } = useAppSelector(selectOffer);
 
@@ -133,7 +133,7 @@ const OfferContainer = ({
             orderResponse.offerId === longOfferId &&
             orderResponse.customerId === customerId
           ) ||
-          !orderResponse?.paymentMethodId
+          orderResponse?.paymentMethodId === undefined
         ) {
           removeData('CLEENG_ORDER_ID');
           createOrderHandler(longOfferId);


### PR DESCRIPTION
### Description

One of the initial values of the paymentMethodId which is 0 should be treated as a normal value when in the previous condition it was treated as an error value and was causing order recreation.

### Updates

Update a condition to recreate order only if the paymentMethodId is not part of the order (some error)

### Screenshots

### Testing

### Additional Notes
