### PR TITLE
fix/MSSDK-1746: P2 TOD 2.0 - payment can't be finalized 

### DIFF
--- a/src/components/AdditionalProfileInfo/AdditionalProfileInfo.js
+++ b/src/components/AdditionalProfileInfo/AdditionalProfileInfo.js
@@ -7,7 +7,7 @@ import MyAccountInput from 'components/MyAccountInput';
 import SelectLegacy, {
   mapToSelectFormat
 } from 'components/SelectLegacy/SelectLegacy';
-import CheckboxLegacy from 'components/CheckboxLegacy';
+import Checkbox from 'components/Checkbox';
 import useMessage from 'hooks/useMessage';
 import { updateCaptureAnswers } from 'api';
 import {
@@ -127,8 +127,9 @@ const AdditionalProfileInfo = ({ data, isLoading, updateCaptureOption }) => {
             if (setting.values.length === 1)
               return (
                 <InputWrapStyled key={setting.key}>
-                  <CheckboxLegacy
+                  <Checkbox
                     isMyAccount
+                    id={setting.key}
                     onClickFn={(e, disabled) =>
                       !disabled &&
                       handleCustomSetting(
@@ -136,41 +137,43 @@ const AdditionalProfileInfo = ({ data, isLoading, updateCaptureOption }) => {
                         setting.value ? '' : setting.values[0]
                       )
                     }
-                    checked={setting.value === setting.values[0]}
+                    isChecked={setting.value === setting.values[0]}
                     disabled={isSectionDisabled}
                   >
                     {setting.question}
-                  </CheckboxLegacy>
+                  </Checkbox>
                 </InputWrapStyled>
               );
             if (setting.values.length === 2)
               return (
                 <InputWrapStyled key={setting.key}>
                   <InputLabelStyled>{setting.question}</InputLabelStyled>
-                  <CheckboxLegacy
+                  <Checkbox
                     key={`${setting.key}-01`}
+                    id={`${setting.key}-01`}
                     onClickFn={(e, disabled) =>
                       !disabled &&
                       handleCustomSetting(setting.key, setting.values[0])
                     }
                     isRadioButton
                     disabled={isSectionDisabled}
-                    checked={setting.value === setting.values[0]}
+                    isChecked={setting.value === setting.values[0]}
                   >
                     {setting.values[0]}
-                  </CheckboxLegacy>
-                  <CheckboxLegacy
+                  </Checkbox>
+                  <Checkbox
                     key={`${setting.key}-02`}
+                    id={`${setting.key}-02`}
                     onClickFn={(e, disabled) =>
                       !disabled &&
                       handleCustomSetting(setting.key, setting.values[1])
                     }
                     isRadioButton
                     disabled={isSectionDisabled}
-                    checked={setting.value === setting.values[1]}
+                    isChecked={setting.value === setting.values[1]}
                   >
                     {setting.values[1]}
-                  </CheckboxLegacy>
+                  </Checkbox>
                 </InputWrapStyled>
               );
             return (

--- a/src/components/Adyen/Adyen.js
+++ b/src/components/Adyen/Adyen.js
@@ -139,9 +139,9 @@ const Adyen = ({
 
     const checkbox = (
       <CheckboxLegacy
-        className={`adyen-checkout__bank-checkbox checkbox-wrapper-${methodName}`}
+        className={`adyen-checkout__bank-checkbox ${methodName}-inputWrapper`}
         checked={false}
-        id={`checkbox-${methodName}`}
+        id={`${methodName}-input`}
         onClickFn={(e, _, setIsChecked) => {
           e.target.parentElement.classList.remove(
             'adyen-checkout__bank-checkbox--error'
@@ -162,9 +162,7 @@ const Adyen = ({
         `.adyen-checkout__payment-method__details`
       );
 
-      const doesCheckboxExist = document.querySelector(
-        `#checkbox-${methodName}`
-      );
+      const doesCheckboxExist = document.querySelector(`#${methodName}-input`);
 
       if (!doesCheckboxExist) {
         const checkboxWrapper = document.createElement('div');
@@ -289,19 +287,21 @@ const Adyen = ({
     const isBancontactCard =
       selectedPaymentMethodRef?.current?.methodName === 'bancontact_card';
 
-    let checkbox = document.querySelector(`#checkbox-${methodName}`);
-    let checkboxWrapper = document.querySelector(
-      `.checkbox-wrapper-${methodName}`
-    );
+    let checkbox = document.querySelector(`#${methodName}-input`);
+    let checkboxWrapper = document.querySelector(`.${methodName}-inputWrapper`);
 
     // condition below needs to be verified when new 'scheme' is added
     if (methodName === 'scheme') {
       const schemeCheckbox = document.querySelector(
-        `#checkbox-${isBancontactCard ? 'bcmc' : 'card'}`
+        `#${isBancontactCard ? 'bcmc' : 'card'}-input`
+      );
+
+      const schemeCheckboxWrapper = document.querySelector(
+        `.${isBancontactCard ? 'bcmc' : 'card'}-inputWrapper`
       );
 
       checkbox = schemeCheckbox;
-      checkboxWrapper = schemeCheckbox.parentElement;
+      checkboxWrapper = schemeCheckboxWrapper;
     }
 
     if (!checkbox?.checked) {

--- a/src/components/Adyen/Adyen.js
+++ b/src/components/Adyen/Adyen.js
@@ -141,6 +141,7 @@ const Adyen = ({
       <CheckboxLegacy
         className={`adyen-checkout__bank-checkbox checkbox-${methodName}`}
         checked={false}
+        id={`checkbox-${methodName}`}
         onClickFn={(e, _, setIsChecked) => {
           e.target.parentElement.classList.remove(
             'adyen-checkout__bank-checkbox--error'
@@ -288,17 +289,21 @@ const Adyen = ({
     const isBancontactCard =
       selectedPaymentMethodRef?.current?.methodName === 'bancontact_card';
 
-    let checkbox = document.querySelector(`.checkbox-${methodName}`);
+    let checkbox = document.querySelector(`#checkbox-${methodName}`);
+    let checkboxWrapper = document.querySelector(`.checkbox-${methodName}`);
 
     // condition below needs to be verified when new 'scheme' is added
     if (methodName === 'scheme') {
-      checkbox = document.querySelector(
-        `.checkbox-${isBancontactCard ? 'bcmc' : 'card'}`
+      const schemeCheckbox = document.querySelector(
+        `#checkbox-${isBancontactCard ? 'bcmc' : 'card'}`
       );
+
+      checkbox = schemeCheckbox;
+      checkboxWrapper = schemeCheckbox.parentElement;
     }
 
     if (!checkbox?.checked) {
-      checkbox.classList.add('adyen-checkout__bank-checkbox--error');
+      checkboxWrapper.classList.add('adyen-checkout__bank-checkbox--error');
       return false;
     }
 

--- a/src/components/Adyen/Adyen.js
+++ b/src/components/Adyen/Adyen.js
@@ -139,7 +139,7 @@ const Adyen = ({
 
     const checkbox = (
       <CheckboxLegacy
-        className={`adyen-checkout__bank-checkbox checkbox-${methodName}`}
+        className={`adyen-checkout__bank-checkbox checkbox-wrapper-${methodName}`}
         checked={false}
         id={`checkbox-${methodName}`}
         onClickFn={(e, _, setIsChecked) => {
@@ -163,7 +163,7 @@ const Adyen = ({
       );
 
       const doesCheckboxExist = document.querySelector(
-        `.checkbox-${methodName}`
+        `#checkbox-${methodName}`
       );
 
       if (!doesCheckboxExist) {
@@ -290,7 +290,9 @@ const Adyen = ({
       selectedPaymentMethodRef?.current?.methodName === 'bancontact_card';
 
     let checkbox = document.querySelector(`#checkbox-${methodName}`);
-    let checkboxWrapper = document.querySelector(`.checkbox-${methodName}`);
+    let checkboxWrapper = document.querySelector(
+      `.checkbox-wrapper-${methodName}`
+    );
 
     // condition below needs to be verified when new 'scheme' is added
     if (methodName === 'scheme') {

--- a/src/components/CheckboxLegacy/CheckboxLegacy.js
+++ b/src/components/CheckboxLegacy/CheckboxLegacy.js
@@ -121,7 +121,7 @@ CheckboxLegacy.defaultProps = {
   isRadioButton: false,
   termsUrl: '',
   isPayPal: false,
-  id: ''
+  id: null
 };
 
 export default CheckboxLegacy;

--- a/src/components/CheckboxLegacy/CheckboxLegacy.js
+++ b/src/components/CheckboxLegacy/CheckboxLegacy.js
@@ -41,13 +41,13 @@ const CheckboxLegacy = ({
           e.stopPropagation();
           onClickFn(e, disabled, setIsChecked);
         }}
-        role='checkbox'
         tabIndex='-1'
         aria-checked={isChecked}
         checked={isChecked}
         aria-label={children}
         className={className}
         $disabled={disabled}
+        data-testid='checkbox-legacy'
       >
         <HiddenCheckboxInput
           id={id}

--- a/src/components/CheckboxLegacy/CheckboxLegacy.js
+++ b/src/components/CheckboxLegacy/CheckboxLegacy.js
@@ -7,6 +7,7 @@ import {
   CheckFrameStyled,
   CheckMarkStyled,
   ConsentDefinitionStyled,
+  HiddenCheckboxInput,
   TermsLinkStyled
 } from './CheckboxLegacyStyled';
 
@@ -21,7 +22,8 @@ const CheckboxLegacy = ({
   disabled,
   isRadioButton,
   termsUrl,
-  isPayPal
+  isPayPal,
+  id
 }) => {
   const [isChecked, setIsChecked] = useState(checked);
   const { t } = useTranslation();
@@ -47,6 +49,13 @@ const CheckboxLegacy = ({
         className={className}
         $disabled={disabled}
       >
+        <HiddenCheckboxInput
+          id={id}
+          type='checkbox'
+          checked={isChecked}
+          disabled={disabled}
+          required={required}
+        />
         <CheckFrameStyled
           $error={error && required && !isChecked}
           tabIndex='0'
@@ -96,7 +105,8 @@ CheckboxLegacy.propTypes = {
   disabled: PropTypes.bool,
   isRadioButton: PropTypes.bool,
   termsUrl: PropTypes.string,
-  isPayPal: PropTypes.bool
+  isPayPal: PropTypes.bool,
+  id: PropTypes.string
 };
 
 CheckboxLegacy.defaultProps = {
@@ -110,7 +120,8 @@ CheckboxLegacy.defaultProps = {
   disabled: false,
   isRadioButton: false,
   termsUrl: '',
-  isPayPal: false
+  isPayPal: false,
+  id: ''
 };
 
 export default CheckboxLegacy;

--- a/src/components/CheckboxLegacy/CheckboxLegacy.test.js
+++ b/src/components/CheckboxLegacy/CheckboxLegacy.test.js
@@ -8,18 +8,20 @@ import CheckboxLegacy from 'components/CheckboxLegacy';
 describe('CheckboxLegacy component', () => {
   test('should render correctly without props', () => {
     render(<CheckboxLegacy />);
-    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+    expect(screen.getByTestId('checkbox-legacy')).toBeInTheDocument();
   });
 
   test('should render correctly with children', () => {
     render(<CheckboxLegacy>Test label</CheckboxLegacy>);
-    expect(screen.getByRole('checkbox')).toBeInTheDocument();
-    expect(screen.getByRole('checkbox')).toHaveTextContent('Test label');
+    expect(screen.getByTestId('checkbox-legacy')).toBeInTheDocument();
+    expect(screen.getByTestId('checkbox-legacy')).toHaveTextContent(
+      'Test label'
+    );
   });
 
   test('should render as radio button when isRadioButton prop is passed', () => {
     const { container } = render(<CheckboxLegacy isRadioButton />);
-    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+    expect(screen.getByTestId('checkbox-legacy')).toBeInTheDocument();
     expect(
       container.getElementsByClassName('msd__consents__frame--radio').length
     ).toBe(1);
@@ -27,21 +29,23 @@ describe('CheckboxLegacy component', () => {
 
   test('should be disabled when disabled prop is passed', () => {
     render(<CheckboxLegacy disabled />);
-    expect(screen.getByRole('checkbox')).toBeInTheDocument();
-    expect(screen.getByRole('checkbox')).toHaveClass('msd__consents--disabled');
+    expect(screen.getByTestId('checkbox-legacy')).toBeInTheDocument();
+    expect(screen.getByTestId('checkbox-legacy')).toHaveClass(
+      'msd__consents--disabled'
+    );
   });
 
   test('should be checked when checked prop is true', () => {
     render(<CheckboxLegacy checked />);
-    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+    expect(screen.getByTestId('checkbox-legacy')).toBeInTheDocument();
     expect(screen.getByTestId('checkmark')).toBeInTheDocument();
   });
 
   test('should be calling onClick when user click', async () => {
     const onClickFunction = jest.fn();
     render(<CheckboxLegacy onClickFn={onClickFunction} />);
-    await userEvent.click(screen.getByRole('checkbox'));
-    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+    await userEvent.click(screen.getByTestId('checkbox-legacy'));
+    expect(screen.getByTestId('checkbox-legacy')).toBeInTheDocument();
     expect(onClickFunction).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/CheckboxLegacy/CheckboxLegacyStyled.js
+++ b/src/components/CheckboxLegacy/CheckboxLegacyStyled.js
@@ -33,6 +33,13 @@ export const CheckboxStyled = styled.div.attrs((props) => ({
     `}
 `;
 
+export const HiddenCheckboxInput = styled.input`
+  position: absolute;
+  width: 1em;
+  height: 1em;
+  opacity: 0;
+`;
+
 export const ConsentDefinitionStyled = styled.div.attrs((props) => ({
   className: `msd__consents__text ${
     props.$checked ? 'msd__consents__text--checked' : ''

--- a/src/components/CheckoutConsents/CheckoutConsents.js
+++ b/src/components/CheckoutConsents/CheckoutConsents.js
@@ -7,14 +7,14 @@ import Header from 'components/Header';
 import Footer from 'components/Footer';
 import Loader from 'components/Loader';
 import Button from 'components/Button';
-import CheckboxLegacy from 'components/CheckboxLegacy';
+import Checkbox from 'components/Checkbox';
 import {
   CheckoutConsentsStyled,
   CheckoutConsentsContentStyled,
   CheckoutConsentsTitleStyled,
   CheckoutConsentsSubTitleStyled,
   CheckoutConsentsListStyled,
-  CheckoutConsentsCheckbox,
+  CheckoutConsentsListItem,
   CheckoutConsentsError
 } from './CheckoutConsentsStyled';
 
@@ -117,21 +117,22 @@ const CheckoutConsents = ({ onSuccess }) => {
               </CheckoutConsentsSubTitleStyled>
               <CheckoutConsentsListStyled role='list'>
                 {consents.map((consent) => (
-                  <CheckoutConsentsCheckbox key={consent.name}>
-                    <CheckboxLegacy
+                  <CheckoutConsentsListItem key={consent.name}>
+                    <Checkbox
                       isMyAccount
+                      id={consent.name}
                       onClickFn={(e, isConsentDisabled) =>
                         handleClick(e, isConsentDisabled, consent)
                       }
-                      checked={consent.state === 'accepted'}
+                      isChecked={consent.state === 'accepted'}
                       required={consent.required}
                     >
                       {translateConsents(consent.label, t)}
-                    </CheckboxLegacy>
+                    </Checkbox>
                     <CheckoutConsentsError>
                       {consent.error}
                     </CheckoutConsentsError>
-                  </CheckoutConsentsCheckbox>
+                  </CheckoutConsentsListItem>
                 ))}
                 {generalError && (
                   <CheckoutConsentsError center>

--- a/src/components/CheckoutConsents/CheckoutConsentsStyled.js
+++ b/src/components/CheckoutConsents/CheckoutConsentsStyled.js
@@ -62,7 +62,7 @@ export const CheckoutConsentsListStyled = styled.ul.attrs(() => ({
   list-style: none;
 `;
 
-export const CheckoutConsentsCheckbox = styled.li``;
+export const CheckoutConsentsListItem = styled.li``;
 
 export const CheckoutConsentsError = styled.div.attrs(() => ({
   className: 'msd__consents__error'

--- a/src/components/Consents/Consents.test.tsx
+++ b/src/components/Consents/Consents.test.tsx
@@ -86,11 +86,12 @@ describe('Consents component', () => {
       </Provider>
     );
 
-    expect(screen.getByRole('checkbox', { checked: false })).toHaveTextContent(
-      publisherConsents[0].label
-    );
-    expect(screen.getByRole('checkbox', { checked: true })).toHaveTextContent(
-      publisherConsents[1].label
-    );
+    expect(
+      screen.getByRole('checkbox', { checked: false }).parentElement
+    ).toHaveTextContent(publisherConsents[0].label);
+
+    expect(
+      screen.getByRole('checkbox', { checked: true }).parentElement
+    ).toHaveTextContent(publisherConsents[1].label);
   });
 });

--- a/src/components/Consents/Consents.tsx
+++ b/src/components/Consents/Consents.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import CheckboxLegacy from 'components/CheckboxLegacy';
+import Checkbox from 'components/Checkbox';
 import Loader from 'components/Loader';
 import { useTranslation } from 'react-i18next';
 import { useAppDispatch, useAppSelector } from 'redux/store';
@@ -77,17 +77,18 @@ const Consents = ({ error, onChangeFn }: ConsentsProps) => {
     <ConsentsWrapperStyled>
       <FieldsetStyled>
         <InvisibleLegend>Consents </InvisibleLegend>
-        {publisherConsents.map(({ label, required }, index) => {
+        {publisherConsents.map(({ label, required, name }, index) => {
           return (
-            <CheckboxLegacy
+            <Checkbox
               onClickFn={() => dispatch(setChecked(index))}
-              checked={checked[index]}
+              isChecked={checked[index]}
+              id={name}
               error={error}
-              key={label}
+              key={name}
               required={required && !checked[index]}
             >
               {translateConsents(label, t) + (required ? '*' : '')}
-            </CheckboxLegacy>
+            </Checkbox>
           );
         })}
       </FieldsetStyled>

--- a/src/components/Payment/PayPal/PayPal.tsx
+++ b/src/components/Payment/PayPal/PayPal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { ChangeEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAppSelector } from 'redux/store';
 import { selectOnlyOrder } from 'redux/orderSlice';
@@ -7,7 +7,7 @@ import { selectDeliveryDetails } from 'redux/deliveryDetailsSlice';
 import { ReactComponent as PaypalLogo } from 'assets/images/paymentMethods/PayPalColor.svg';
 import Button from 'components/Button';
 import { getStandardCopy } from 'util/paymentMethodHelper';
-import CheckboxLegacy from 'components/CheckboxLegacy';
+import Checkbox from 'components/Checkbox';
 import { selectTermsUrl } from 'redux/publisherConfigSlice';
 import {
   PayPalContentStyled,
@@ -35,11 +35,13 @@ const PayPal = ({
 
   const handleSubmit = () => {
     const checkbox = document.querySelector(
-      `.checkbox-paypal`
+      `#checkbox-paypal`
     ) as HTMLInputElement;
 
+    const checkboxWrapper = checkbox.parentElement as HTMLLabelElement;
+
     if (!checkbox?.checked) {
-      checkbox.classList.add('adyen-checkout__bank-checkbox--error');
+      checkboxWrapper.classList.add('adyen-checkout__bank-checkbox--error');
       return;
     }
 
@@ -79,21 +81,24 @@ const PayPal = ({
           )}
       </CopyStyled>
       <CheckboxWrapperStyled>
-        <CheckboxLegacy
+        <Checkbox
           className='adyen-checkout__bank-checkbox checkbox-paypal'
-          checked={isChecked}
-          onClickFn={(e) => {
-            e.target.parentElement.classList.remove(
+          id='checkbox-paypal'
+          isChecked={isChecked}
+          onClickFn={(event?: ChangeEvent<HTMLInputElement> | undefined) => {
+            event?.target.parentElement?.classList.remove(
               'adyen-checkout__bank-checkbox--error'
             );
 
-            setIsChecked(!e.target.checked);
+            if (event) {
+              setIsChecked(event?.target.checked);
+            }
           }}
           termsUrl={termsUrl}
           isPayPal
         >
           {getStandardCopy(isMyAccount, offer, order, isGift)}
-        </CheckboxLegacy>
+        </Checkbox>
       </CheckboxWrapperStyled>
       <Button
         theme='paypal'

--- a/src/components/Payment/PayPal/PayPal.tsx
+++ b/src/components/Payment/PayPal/PayPal.tsx
@@ -34,16 +34,14 @@ const PayPal = ({
   const [isChecked, setIsChecked] = useState(false);
 
   const handleSubmit = () => {
-    const checkbox = document.querySelector(
-      `#checkbox-paypal`
-    ) as HTMLInputElement;
+    const checkbox: HTMLInputElement | null =
+      document.querySelector(`#paypal-input`);
 
-    const checkboxWrapper = document.querySelector(
-      `.checkbox-wrapper-paypal`
-    ) as HTMLInputElement;
+    const checkboxWrapper: HTMLInputElement | null =
+      document.querySelector(`.paypal-inputLabel`);
 
     if (!checkbox?.checked) {
-      checkboxWrapper.classList.add('adyen-checkout__bank-checkbox--error');
+      checkboxWrapper?.classList.add('adyen-checkout__bank-checkbox--error');
       return;
     }
 
@@ -84,17 +82,19 @@ const PayPal = ({
       </CopyStyled>
       <CheckboxWrapperStyled>
         <Checkbox
-          className='adyen-checkout__bank-checkbox checkbox-wrapper-paypal'
-          id='checkbox-paypal'
+          className='adyen-checkout__bank-checkbox paypal-inputLabel'
+          id='paypal-input'
           isChecked={isChecked}
           onClickFn={(event?: ChangeEvent<HTMLInputElement> | undefined) => {
-            event?.target.parentElement?.classList.remove(
+            if (!event) {
+              return;
+            }
+
+            event.target.parentElement?.classList.remove(
               'adyen-checkout__bank-checkbox--error'
             );
 
-            if (event) {
-              setIsChecked(event?.target.checked);
-            }
+            setIsChecked(event.target.checked);
           }}
           termsUrl={termsUrl}
           isPayPal

--- a/src/components/Payment/PayPal/PayPal.tsx
+++ b/src/components/Payment/PayPal/PayPal.tsx
@@ -38,7 +38,9 @@ const PayPal = ({
       `#checkbox-paypal`
     ) as HTMLInputElement;
 
-    const checkboxWrapper = checkbox.parentElement as HTMLLabelElement;
+    const checkboxWrapper = document.querySelector(
+      `.checkbox-wrapper-paypal`
+    ) as HTMLInputElement;
 
     if (!checkbox?.checked) {
       checkboxWrapper.classList.add('adyen-checkout__bank-checkbox--error');
@@ -82,7 +84,7 @@ const PayPal = ({
       </CopyStyled>
       <CheckboxWrapperStyled>
         <Checkbox
-          className='adyen-checkout__bank-checkbox checkbox-paypal'
+          className='adyen-checkout__bank-checkbox checkbox-wrapper-paypal'
           id='checkbox-paypal'
           isChecked={isChecked}
           onClickFn={(event?: ChangeEvent<HTMLInputElement> | undefined) => {

--- a/src/components/Payment/PayPal/PayPal.tsx
+++ b/src/components/Payment/PayPal/PayPal.tsx
@@ -37,11 +37,11 @@ const PayPal = ({
     const checkbox: HTMLInputElement | null =
       document.querySelector(`#paypal-input`);
 
-    const checkboxWrapper: HTMLInputElement | null =
+    const checkboxLabel: HTMLInputElement | null =
       document.querySelector(`.paypal-inputLabel`);
 
     if (!checkbox?.checked) {
-      checkboxWrapper?.classList.add('adyen-checkout__bank-checkbox--error');
+      checkboxLabel?.classList.add('adyen-checkout__bank-checkbox--error');
       return;
     }
 
@@ -85,7 +85,7 @@ const PayPal = ({
           className='adyen-checkout__bank-checkbox paypal-inputLabel'
           id='paypal-input'
           isChecked={isChecked}
-          onClickFn={(event?: ChangeEvent<HTMLInputElement> | undefined) => {
+          onClickFn={(event: ChangeEvent<HTMLInputElement> | undefined) => {
             if (!event) {
               return;
             }

--- a/src/components/UpdateSubscription/components/Survey.tsx
+++ b/src/components/UpdateSubscription/components/Survey.tsx
@@ -13,7 +13,7 @@ import {
   ReasonsWrapper,
   StyledItem
 } from 'components/UpdateSubscription/UpdateSubscriptionStyled';
-import CheckboxLegacy from 'components/CheckboxLegacy';
+import Checkbox from 'components/Checkbox';
 import Loader from 'components/Loader';
 import { selectOffers } from 'redux/offersSlice';
 import { CancellationReason } from 'containers/PlanDetails/PlanDetails.types';
@@ -145,13 +145,14 @@ const Survey = ({
           <ReasonsWrapper>
             {cancellationReasonsToShow.map(({ key, value }) => (
               <StyledItem key={key}>
-                <CheckboxLegacy
+                <Checkbox
+                  id={key}
                   isRadioButton
                   onClickFn={() => handleCheckboxClick(value)}
-                  checked={value === checkedReason}
+                  isChecked={value === checkedReason}
                 >
                   {t(key, value)}
-                </CheckboxLegacy>
+                </Checkbox>
               </StyledItem>
             ))}
           </ReasonsWrapper>


### PR DESCRIPTION
### Description

After checking it looks like it’s frontend issue with checking the checkbox state. Checkbox state value returns `undefined` and blocks further payment processing. Fix checking of checkbox state, find more bulletproof way to check it.

### Updates

Used new `Checkbox` component in `PayPal.tsx` and added invisible input element to `CheckboxLegacy` for Adyen payment methods - to change checking state of checkbox to `checked` value of input element

