### PR TITLE
fix/MSSDK-1752: Make sure that window is available before onload call

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -24,18 +24,20 @@ import eventDispatcher, {
   MSSDK_PURCHASE_SUCCESSFUL
 } from 'util/eventDispatcher';
 
-window.onload = () => {
-  const queryString = window.location.search;
-  const urlParams = new URLSearchParams(queryString);
-  const externalPaymentId = urlParams.get('externalPaymentId');
-  if (externalPaymentId) {
-    eventDispatcher(MSSDK_PURCHASE_SUCCESSFUL, {
-      payment: {
-        externalPaymentId
-      }
-    });
-  }
-};
+if (typeof window !== 'undefined') {
+  window.onload = () => {
+    const queryString = window.location.search;
+    const urlParams = new URLSearchParams(queryString);
+    const externalPaymentId = urlParams.get('externalPaymentId');
+    if (externalPaymentId) {
+      eventDispatcher(MSSDK_PURCHASE_SUCCESSFUL, {
+        payment: {
+          externalPaymentId
+        }
+      });
+    }
+  };
+}
 
 export {
   // Identity Management


### PR DESCRIPTION
### Description

There was an error in one of our clients that `ReferenceError: window is not defined` so to make sure that it wont happen again we add check if window is available before calling `onload`.

### Updates

- add if statement in the `package.ts`

### Screenshots

### Testing

### Additional Notes
