### PR TITLE
fix/MSSDK-1754: Unable to save profile details form when date of birth field is not present

### DIFF
--- a/src/components/ProfileDetails/ProfileDetails.jsx
+++ b/src/components/ProfileDetails/ProfileDetails.jsx
@@ -221,11 +221,9 @@ class ProfileDetails extends Component {
 
   isBirthDateValid = () => {
     const { updated } = this.state;
-    const {
-      t,
-      birthDate: { enabled, required }
-    } = this.props;
+    const { t, birthDate } = this.props;
 
+    const { enabled, required } = birthDate || {};
     const isBirthDateRequired = enabled && required;
 
     if (isBirthDateRequired && !updated.birthDate) {
@@ -252,7 +250,7 @@ class ProfileDetails extends Component {
       (setting) => setting.key === 'firstNameLastName'
     );
 
-    const { enabled, required } = namesSettings;
+    const { enabled, required } = namesSettings || {};
 
     const areNamesRequired = enabled && required;
 
@@ -344,11 +342,9 @@ class ProfileDetails extends Component {
 
   isPhoneNumberValid = () => {
     const { updated } = this.state;
-    const {
-      t,
-      phoneNumber: { enabled, required }
-    } = this.props;
+    const { t, phoneNumber } = this.props;
 
+    const { enabled, required } = phoneNumber || {};
     const isPhoneNumberRequired = enabled && required;
 
     if (isPhoneNumberRequired && !updated.phoneNumber) {
@@ -385,11 +381,9 @@ class ProfileDetails extends Component {
 
   isCompanyNameValid = () => {
     const { updated } = this.state;
-    const {
-      t,
-      companyName: { enabled, required }
-    } = this.props;
+    const { t, companyName } = this.props;
 
+    const { enabled, required } = companyName || {};
     const isCompanyNameRequired = enabled && required;
 
     if (isCompanyNameRequired && !updated.companyName) {


### PR DESCRIPTION
### Description

User is unable to save profile details form when date of birth field is not present with specific capture settings

### Updates

Changed destructuring of `enabled` and `required` properties to avoid destructuring `null` field

