### PR TITLE
fix/MSSDK-1829: Set the width of the Paypal icon

### DIFF
--- a/src/components/Transactions/TransactionsStyled.ts
+++ b/src/components/Transactions/TransactionsStyled.ts
@@ -127,7 +127,7 @@ export const ButtonTextStyled = styled.span.attrs(() => ({
 export const LogoWrapStyled = styled.div`
   display: flex;
   height: 42px;
-  min-width: 42px;
+  width: 42px;
   justify-content: center;
   align-items: center;
   border: 1px solid #d4d4df;


### PR DESCRIPTION
### Description

Fix PayPal icon width

### Updates

Change min-width to width

### Screenshots
<img width="918" alt="image" src="https://github.com/user-attachments/assets/05a107de-af52-41dd-9742-46867005b3f1">


### Testing

### Additional Notes
