### PR TITLE
feat/MSSDK-1831: extend the configure method of Cleeng script to enable external SSO

### DIFF
--- a/src/scripts/cleeng.js
+++ b/src/scripts/cleeng.js
@@ -3,10 +3,10 @@ import { CLEENG_EXPOSED_COMPONENTS } from './constants';
 import { kebabCase } from './utils';
 
 export default class Cleeng {
-  configure({ publisherId, offerId }) {
+  configure({ publisherId, offerId, cleengAuthToken, cleengRefreshToken }) {
     if (!publisherId) {
       throw new Error(
-        "Cleeng needs the publisher's ID in order to configure properly. Please pass your publisher ID."
+        "Cleeng needs the publisher's ID in order to configure properly. Please pass your Cleeng publisher ID."
       );
     }
 
@@ -15,7 +15,9 @@ export default class Cleeng {
       this.components[componentName] = new CleengComponent({
         slug: kebabCase(componentName),
         offerId,
-        publisherId
+        publisherId,
+        cleengAuthToken,
+        cleengRefreshToken
       });
     });
   }

--- a/src/scripts/constants.js
+++ b/src/scripts/constants.js
@@ -18,3 +18,5 @@ export const CLEENG_EXPOSED_COMPONENTS = {
   checkoutConsents: null,
   thankYou: null
 };
+
+export const CLEENG_CREDENTIALS_MESSAGE_TYPE = 'cleeng-credentials';


### PR DESCRIPTION
### Description

Configure method now accepts JWT and refresh token.
It uses postMessage API to communicate these values to the hosted MSSDK.