### PR TITLE
feat/MSSDK-1861 Fix styling inconsistencies after using setTheme colors from backend 

### DIFF
--- a/src/assets/images/checkboxCheckmark.svg
+++ b/src/assets/images/checkboxCheckmark.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 23 23">
+  <defs>
+    <style>
+      .cls-2 {
+        fill: none;
+        stroke: #fff;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+        stroke-width: 2.3px;
+      }
+    </style>
+  </defs>
+  <g id="Group_2444" data-name="Group 2444" transform="translate(-2630 -325)">
+    <g id="Group_2439" data-name="Group 2439" transform="translate(-2260 -536)">
+      <rect id="Rectangle_2907" data-name="Rectangle 2907" class="cls-1" width="23" height="23" rx="4" transform="translate(4890 861)"/>
+      <path id="Path_1942" data-name="Path 1942" class="cls-2" d="M9635.432-7145.427l3.764,3.791,4.215-4.244,3.989-4.018" transform="translate(-4739.931 8018.397)"/>
+    </g>
+  </g>
+</svg>

--- a/src/components/AdditionalProfileInfo/AdditionalProfileInfo.jsx
+++ b/src/components/AdditionalProfileInfo/AdditionalProfileInfo.jsx
@@ -206,6 +206,7 @@ const AdditionalProfileInfo = ({ data, isLoading, updateCaptureOption }) => {
                   resetMessage();
                 }}
                 width='100%'
+                theme='confirm'
               >
                 {t(
                   'additional-profile-info.button.edit-profile',

--- a/src/components/Adyen/Adyen.jsx
+++ b/src/components/Adyen/Adyen.jsx
@@ -143,9 +143,13 @@ const Adyen = ({
         checked={false}
         id={`${methodName}-input`}
         onClickFn={(e, _, setIsChecked) => {
-          e.target.parentElement.classList.remove(
-            'adyen-checkout__bank-checkbox--error'
-          );
+          e.target.classList.remove('adyen-checkout__bank-checkbox--error');
+
+          if (e.key === ' ') {
+            e.target.parentElement.classList.remove(
+              'adyen-checkout__bank-checkbox--error'
+            );
+          }
 
           setIsChecked(!e.target.checked);
         }}

--- a/src/components/Adyen/AdyenStyled.js
+++ b/src/components/Adyen/AdyenStyled.js
@@ -66,7 +66,6 @@ const AdyenStyled = styled.div.attrs(() => ({
 
   .adyen-checkout__input,
   .adyen-checkout__dropdown__button {
-    color: ${FontColor} !important;
     border-color: #d8ddea;
     box-shadow: none;
   }
@@ -100,7 +99,13 @@ const AdyenStyled = styled.div.attrs(() => ({
   }
 
   .checkbox-wrapper {
+    display: flex;
+    flex-direction: column;
     margin: 10px 20px 20px 20px;
+  }
+
+  .adyen-checkout__card-input {
+    text-align: start;
   }
 
   .adyen-checkout__bank-checkbox {

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -84,7 +84,7 @@ const Checkbox = ({
               $isMyAccount={isMyAccount}
               $isRadioButton={isRadioButton}
             >
-              <CheckboxCheckmark />
+              {!isRadioButton && <CheckboxCheckmark />}
             </CheckMarkStyled>
           )}
         </CheckFrameStyled>

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,5 +1,6 @@
 import { ChangeEvent } from 'react';
 import { useTranslation } from 'react-i18next';
+import CheckboxCheckmark from 'assets/images/checkboxCheckmark.svg';
 
 import {
   HiddenCheckboxInput,
@@ -82,7 +83,9 @@ const Checkbox = ({
               data-testid='checkmark'
               $isMyAccount={isMyAccount}
               $isRadioButton={isRadioButton}
-            />
+            >
+              <CheckboxCheckmark />
+            </CheckMarkStyled>
           )}
         </CheckFrameStyled>
         <ConsentDefinitionStyled

--- a/src/components/Checkbox/CheckboxStyled.tsx
+++ b/src/components/Checkbox/CheckboxStyled.tsx
@@ -79,6 +79,8 @@ export const ConsentDefinitionStyled = styled.div.attrs(
 
   font-weight: 400;
   text-align: left;
+
+  user-select: none;
   a {
     color: ${FontColor};
 
@@ -100,9 +102,7 @@ export const CheckFrameStyled = styled.div.attrs(
     className: `msd__consents__frame ${
       props.$error ? 'msd__consents__frame--error' : ''
     } ${props.$checked ? 'msd__consents__frame--checked' : ''}
-  ${props.$isRadioButton ? 'msd__consents__frame--radio' : ''} ${
-      props.$isMyAccount ? 'msd__consents__frame--account' : ''
-    }`
+  ${props.$isRadioButton ? 'msd__consents__frame--radio' : ''}`
   })
 )<CheckFrameStyledProps>`
   position: relative;
@@ -133,13 +133,6 @@ export const CheckFrameStyled = styled.div.attrs(
     css`
       border: 1px solid ${ConfirmColor};
     `}
-
-  ${(props) =>
-    props.$isMyAccount &&
-    props.$checked &&
-    css`
-      border-color: ${ConfirmColor};
-    `}
 `;
 
 export const CheckMarkStyled = styled.div.attrs(
@@ -153,10 +146,13 @@ export const CheckMarkStyled = styled.div.attrs(
 
   width: 13px;
   height: 10px;
-  top: 4px;
-  left: 3px;
-  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMi44MjgiIGhlaWdodD0iOS44MjgiIHZpZXdCb3g9IjAgMCAxMi44MjggOS44MjgiPjxkZWZzPjxzdHlsZT4uYXtmaWxsOm5vbmU7c3Ryb2tlOiM3YzhjYTU7c3Ryb2tlLWxpbmVjYXA6cm91bmQ7c3Ryb2tlLXdpZHRoOjJweDt9PC9zdHlsZT48L2RlZnM+PGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTE4My4wODYgLTM5OS4wODYpIj48bGluZSBjbGFzcz0iYSIgeDI9IjMiIHkyPSIzIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxODQuNSA0MDQuNSkiLz48bGluZSBjbGFzcz0iYSIgeDE9IjciIHkyPSI3IiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxODcuNSA0MDAuNSkiLz48L2c+PC9zdmc+');
-  background-repeat: no-repeat;
+  top: -1px;
+  left: -1px;
+
+  svg {
+    fill: ${ConfirmColor};
+  }
+
   ${(props) =>
     props.$isRadioButton &&
     css`
@@ -177,9 +173,6 @@ export const CheckMarkStyled = styled.div.attrs(
       height: 20px;
       top: -1px;
       left: -1px;
-      background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMyIgaGVpZ2h0PSIyMyIgdmlld0JveD0iMCAwIDIzIDIzIj4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmNscy0xIHsKICAgICAgICBmaWxsOiAjNEVCN0ExOwogICAgICB9CgogICAgICAuY2xzLTIgewogICAgICAgIGZpbGw6IG5vbmU7CiAgICAgICAgc3Ryb2tlOiAjZmZmOwogICAgICAgIHN0cm9rZS1saW5lY2FwOiByb3VuZDsKICAgICAgICBzdHJva2UtbGluZWpvaW46IHJvdW5kOwogICAgICAgIHN0cm9rZS13aWR0aDogMi4zcHg7CiAgICAgIH0KICAgIDwvc3R5bGU+CiAgPC9kZWZzPgogIDxnIGlkPSJHcm91cF8yNDQ0IiBkYXRhLW5hbWU9Ikdyb3VwIDI0NDQiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0yNjMwIC0zMjUpIj4KICAgIDxnIGlkPSJHcm91cF8yNDM5IiBkYXRhLW5hbWU9Ikdyb3VwIDI0MzkiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0yMjYwIC01MzYpIj4KICAgICAgPHJlY3QgaWQ9IlJlY3RhbmdsZV8yOTA3IiBkYXRhLW5hbWU9IlJlY3RhbmdsZSAyOTA3IiBjbGFzcz0iY2xzLTEiIHdpZHRoPSIyMyIgaGVpZ2h0PSIyMyIgcng9IjQiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDQ4OTAgODYxKSIvPgogICAgICA8cGF0aCBpZD0iUGF0aF8xOTQyIiBkYXRhLW5hbWU9IlBhdGggMTk0MiIgY2xhc3M9ImNscy0yIiBkPSJNOTYzNS40MzItNzE0NS40MjdsMy43NjQsMy43OTEsNC4yMTUtNC4yNDQsMy45ODktNC4wMTgiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC00NzM5LjkzMSA4MDE4LjM5NykiLz4KICAgIDwvZz4KICA8L2c+Cjwvc3ZnPgo=');
-      background-position: center;
-      background-size: cover;
     `}
 `;
 

--- a/src/components/CheckboxLegacy/CheckboxLegacy.jsx
+++ b/src/components/CheckboxLegacy/CheckboxLegacy.jsx
@@ -59,7 +59,10 @@ const CheckboxLegacy = ({
         <CheckFrameStyled
           $error={error && required && !isChecked}
           tabIndex='0'
-          onKeyDown={(e) => (e.key === spaceKey ? onClickFn() : null)}
+          checked={isChecked}
+          onKeyDown={(e) =>
+            e.key === spaceKey ? onClickFn(e, disabled, setIsChecked) : null
+          }
           $isMyAccount={isMyAccount}
           $isRadioButton={isRadioButton}
           $checked={isChecked}

--- a/src/components/CheckboxLegacy/CheckboxLegacyStyled.js
+++ b/src/components/CheckboxLegacy/CheckboxLegacyStyled.js
@@ -38,6 +38,7 @@ export const HiddenCheckboxInput = styled.input`
   width: 1em;
   height: 1em;
   opacity: 0;
+  pointer-events: none;
 `;
 
 export const ConsentDefinitionStyled = styled.div.attrs((props) => ({
@@ -51,6 +52,8 @@ export const ConsentDefinitionStyled = styled.div.attrs((props) => ({
 
   font-weight: 400;
   text-align: left;
+  pointer-events: none;
+
   a {
     color: ${FontColor};
 
@@ -83,6 +86,7 @@ export const CheckFrameStyled = styled.div.attrs((props) => ({
   width: 20px;
   min-width: 20px;
   height: 20px;
+  pointer-events: none;
 
   &:focus {
     outline: 2px solid ${FocusColor};
@@ -118,6 +122,7 @@ export const CheckMarkStyled = styled.div.attrs((props) => ({
   } ${props.$isMyAccount ? 'msd__consents__check-mark--account' : ''}`
 }))`
   position: absolute;
+  pointer-events: none;
 
   width: 13px;
   height: 10px;
@@ -172,7 +177,7 @@ export const TermsLinkStyled = styled.a`
   font-size: 11px;
   line-height: 17px;
   text-align: left;
-  color: ${FontColor};
+  color: #515364;
   text-decoration: underline;
   opacity: 0.8;
 

--- a/src/components/CheckboxLegacy/CheckboxLegacyStyled.js
+++ b/src/components/CheckboxLegacy/CheckboxLegacyStyled.js
@@ -53,6 +53,7 @@ export const ConsentDefinitionStyled = styled.div.attrs((props) => ({
   font-weight: 400;
   text-align: left;
   pointer-events: none;
+  user-select: none;
 
   a {
     color: ${FontColor};
@@ -180,6 +181,7 @@ export const TermsLinkStyled = styled.a`
   color: #515364;
   text-decoration: underline;
   opacity: 0.8;
+  user-select: none;
 
   ${(props) =>
     props.$checked &&

--- a/src/components/MyAccountConsents/MyAccountConsents.jsx
+++ b/src/components/MyAccountConsents/MyAccountConsents.jsx
@@ -112,7 +112,7 @@ class MyAccountConsents extends Component {
             onClickFn={(e, isConsentDisabled) =>
               this.handleClick(e, isConsentDisabled, item)
             }
-            checked={item.state === 'accepted'}
+            isChecked={item.state === 'accepted'}
             key={item.name}
             disabled={(isSectionDisabled || item.required) && !showConsentsOnly}
             required={item.required}

--- a/src/components/MyAccountConsents/MyAccountConsentsStyled.js
+++ b/src/components/MyAccountConsents/MyAccountConsentsStyled.js
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 import Button from 'components/Button';
-import CheckboxLegacy from 'components/CheckboxLegacy';
+import Checkbox from 'components/Checkbox';
 import Card from 'components/Card';
 import { mediaFrom } from 'styles/BreakPoints';
 import { ConfirmColor } from 'styles/variables';
@@ -42,7 +42,7 @@ export const ButtonStyled = styled(Button).attrs(() => ({
   `}
 `;
 
-export const CheckboxStyled = styled(CheckboxLegacy).attrs(() => ({
+export const CheckboxStyled = styled(Checkbox).attrs(() => ({
   className: 'msd__profile-consents__checkbox'
 }))`
   align-items: flex-start;

--- a/src/components/MyAccountError/MyAccountErrorStyled.ts
+++ b/src/components/MyAccountError/MyAccountErrorStyled.ts
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components';
-import { FontColor, IconsColor } from 'styles/variables';
+import { ConfirmColor, FontColor, IconsColor } from 'styles/variables';
 import { media } from 'styles/BreakPoints';
 import { WrapStyledProps } from './MyAccountError.types';
 
@@ -35,8 +35,14 @@ export const IconStyled = styled.div.attrs(() => ({
   display: flex;
   justify-content: center;
   margin: auto auto 10px auto;
+
   svg {
     max-width: 490px;
+
+    ellipse {
+      fill: ${ConfirmColor};
+      stroke: ${ConfirmColor};
+    }
   }
 `;
 

--- a/src/components/Password/Password.jsx
+++ b/src/components/Password/Password.jsx
@@ -20,6 +20,7 @@ const Password = ({ showInnerPopup }) => {
           <Button
             width='auto'
             onClickFn={() => showInnerPopup({ type: POPUP_TYPES.editPassword })}
+            theme='confirm'
           >
             {t('Edit Password')}
           </Button>

--- a/src/components/Payment/PayPal/PayPal.tsx
+++ b/src/components/Payment/PayPal/PayPal.tsx
@@ -7,7 +7,7 @@ import { selectDeliveryDetails } from 'appRedux/deliveryDetailsSlice';
 import PaypalLogo from 'assets/images/paymentMethods/PayPalColor.svg';
 import Button from 'components/Button';
 import { getStandardCopy } from 'util/paymentMethodHelper';
-import Checkbox from 'components/Checkbox';
+import CheckboxLegacy from 'components/CheckboxLegacy';
 import { selectTermsUrl } from 'appRedux/publisherConfigSlice';
 import {
   PayPalContentStyled,
@@ -81,26 +81,35 @@ const PayPal = ({
           )}
       </CopyStyled>
       <CheckboxWrapperStyled>
-        <Checkbox
+        <CheckboxLegacy
           className='adyen-checkout__bank-checkbox paypal-inputLabel'
+          checked={isChecked}
           id='paypal-input'
-          isChecked={isChecked}
           onClickFn={(event: ChangeEvent<HTMLInputElement> | undefined) => {
             if (!event) {
               return;
             }
 
-            event.target.parentElement?.classList.remove(
+            if (
+              event.nativeEvent instanceof KeyboardEvent &&
+              event.nativeEvent.key === ' '
+            ) {
+              event.target.parentElement?.classList.remove(
+                'adyen-checkout__bank-checkbox--error'
+              );
+            }
+
+            event.target.classList.remove(
               'adyen-checkout__bank-checkbox--error'
             );
 
-            setIsChecked(event.target.checked);
+            setIsChecked(!event.target.checked);
           }}
           termsUrl={termsUrl}
           isPayPal
         >
           {getStandardCopy(isMyAccount, offer, order, isGift)}
-        </Checkbox>
+        </CheckboxLegacy>
       </CheckboxWrapperStyled>
       <Button
         theme='paypal'

--- a/src/components/Payment/PayPal/PayPalStyled.ts
+++ b/src/components/Payment/PayPal/PayPalStyled.ts
@@ -34,6 +34,9 @@ export const PayPalIconContentStyled = styled.div.attrs(() => ({
 `;
 
 export const CheckboxWrapperStyled = styled.div`
+  display: flex;
+  flex-direction: column;
+
   .msd__consents__text {
     font-size: 11px;
     line-height: 17px;

--- a/src/components/Payment/PayPal/PayPalStyled.ts
+++ b/src/components/Payment/PayPal/PayPalStyled.ts
@@ -45,6 +45,7 @@ export const CheckboxWrapperStyled = styled.div`
 
   .adyen-checkout__bank-checkbox {
     color: #515364;
+    margin-bottom: 20px;
   }
 
   .adyen-checkout__bank-checkbox--error {

--- a/src/components/Payment/PayPal/PayPalStyled.ts
+++ b/src/components/Payment/PayPal/PayPalStyled.ts
@@ -43,6 +43,10 @@ export const CheckboxWrapperStyled = styled.div`
     align-self: start;
   }
 
+  .adyen-checkout__bank-checkbox {
+    color: #515364;
+  }
+
   .adyen-checkout__bank-checkbox--error {
     .msd__consents__frame {
       border-color: ${ErrorColor};

--- a/src/components/PaymentCard/PaymentCardStyled.ts
+++ b/src/components/PaymentCard/PaymentCardStyled.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { White, FontColor } from 'styles/variables';
+import { White, FontColor, ConfirmColor } from 'styles/variables';
 import { mediaFrom } from 'styles/BreakPoints';
 import * as colors from 'styles/variables';
 
@@ -79,7 +79,7 @@ export const CardEditStyled = styled.button.attrs(() => ({
   color: ${White};
 
   padding: 11px 25px;
-  background-color: ${FontColor};
+  background-color: ${ConfirmColor};
   font-size: 14px;
   line-height: 16px;
   font-weight: 600;

--- a/src/components/ProfileDetails/ProfileDetails.jsx
+++ b/src/components/ProfileDetails/ProfileDetails.jsx
@@ -519,6 +519,7 @@ class ProfileDetails extends Component {
                       this.setState({ isSectionDisabled: false })
                     }
                     width='100%'
+                    theme='confirm'
                   >
                     {t('profiledetails.button.edit-profile', 'Edit Profile')}
                   </ButtonStyled>

--- a/src/containers/SubscriptionSwitches/SubscriptionSwitches.component.jsx
+++ b/src/containers/SubscriptionSwitches/SubscriptionSwitches.component.jsx
@@ -107,7 +107,11 @@ const SubscriptionSwitches = ({
   }, [switchSettings]);
 
   if (switchSettingsError) {
-    return <MyAccountError generalError />;
+    return (
+      <WrapStyled>
+        <MyAccountError generalError />;
+      </WrapStyled>
+    );
   }
 
   if (isPopupOpen)


### PR DESCRIPTION
### Description

Some colors are inconsistent after changing theme. For example if client uses dark theme and changes font to white, some texts may not be visible. When client changes main color in low code settings to orange, some buttons or checkboxes are still green.


### Updates

Changed checkboxes behavior, checkbox in `Adyen` behaves correct now to clicking and using space key. Other checkboxes from now are using `ConfirmColor` as background when clicked. Fixed invisible fonts and buttons which used `FontColor` as background


