### PR TITLE
fix/MSSDK-1860: P3 - All Publishers - Reset Password Inconsistency

### DIFF
--- a/src/util/regexConstants.ts
+++ b/src/util/regexConstants.ts
@@ -1,4 +1,4 @@
-export const EMAIL_REGEX = /^(\w+)([+]\w+)?@(\w+)((\.\w{2,})+)$/;
+export const EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 
 export const PHONE_NUMBER_REGEX = /(^[+]?(\d[-|\s]?){4,16})$/;
 

--- a/src/util/validators.ts
+++ b/src/util/validators.ts
@@ -1,9 +1,8 @@
 import i18n from 'i18next';
+import { EMAIL_REGEX } from 'util/regexConstants';
 
 export function validateEmail(email: string) {
-  const re =
-    /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/; //eslint-disable-line
-  return re.test(String(email).toLowerCase());
+  return EMAIL_REGEX.test(String(email).toLowerCase());
 }
 
 export function validateConsents(value: any[], consentDefinitions: any[]) {


### PR DESCRIPTION
### Description

Using emails with `-` sign in domain part shows `incorrect email` error in `PasswordReset` component

### Updates

Used popular email regex to accept all correct email formats, also used in during registering phase


