### PR TITLE
fix/MSSDK-1942: P3 - TODtv - PayPal payment method becomes unselectable

### DIFF
--- a/src/components/Adyen/Adyen.jsx
+++ b/src/components/Adyen/Adyen.jsx
@@ -578,13 +578,19 @@ const Adyen = ({
     }
   }, [discount.applied, discount.type, discountAmount]);
 
+  const handleReloadCachedPage = (event) => {
+    if (event.persisted) {
+      window.location.reload();
+    }
+  };
+
   useEffect(() => {
     // reload page if it was loaded from bfcache
-    window.addEventListener('pageshow', (event) => {
-      if (event.persisted) {
-        window.location.reload();
-      }
-    });
+    window.addEventListener('pageshow', handleReloadCachedPage);
+
+    return () => {
+      window.removeEventListener('pageshow', handleReloadCachedPage);
+    };
   }, []);
 
   useEffect(() => {

--- a/src/components/Adyen/Adyen.jsx
+++ b/src/components/Adyen/Adyen.jsx
@@ -578,21 +578,6 @@ const Adyen = ({
     }
   }, [discount.applied, discount.type, discountAmount]);
 
-  const handleReloadCachedPage = (event) => {
-    if (event.persisted) {
-      window.location.reload();
-    }
-  };
-
-  useEffect(() => {
-    // reload page if it was loaded from bfcache
-    window.addEventListener('pageshow', handleReloadCachedPage);
-
-    return () => {
-      window.removeEventListener('pageshow', handleReloadCachedPage);
-    };
-  }, []);
-
   useEffect(() => {
     if (isDropInPresent) {
       recreateDropIn();

--- a/src/components/Adyen/Adyen.jsx
+++ b/src/components/Adyen/Adyen.jsx
@@ -579,6 +579,15 @@ const Adyen = ({
   }, [discount.applied, discount.type, discountAmount]);
 
   useEffect(() => {
+    // reload page if it was loaded from bfcache
+    window.addEventListener('pageshow', (event) => {
+      if (event.persisted) {
+        window.location.reload();
+      }
+    });
+  }, []);
+
+  useEffect(() => {
     if (isDropInPresent) {
       recreateDropIn();
     }

--- a/src/components/Offer/Offer.tsx
+++ b/src/components/Offer/Offer.tsx
@@ -50,12 +50,20 @@ const Offer = ({
   }, [couponCode]);
 
   useEffect(() => {
-    // reload Payment component if it was loaded from bfcache
-    window.addEventListener('pageshow', (event) => {
+    // PayPal is unclickable after loading page from bfcache
+    // Reload Payment component if it was loaded from bfcache so new Adyen Drop-in and PayPal component are created so there are no empty states or old session data
+
+    const handlePageShow = (event: PageTransitionEvent) => {
       if (event.persisted) {
         setPaymentKey(Date.now());
       }
-    });
+    };
+
+    window.addEventListener('pageshow', handlePageShow);
+
+    return () => {
+      window.removeEventListener('pageshow', handlePageShow);
+    };
   }, []);
 
   if (isFree) {

--- a/src/components/Offer/Offer.tsx
+++ b/src/components/Offer/Offer.tsx
@@ -30,6 +30,8 @@ const Offer = ({
 }: OfferProps) => {
   const { t } = useTranslation();
   const [coupon, setCoupon] = useState('');
+  const [paymentKey, setPaymentKey] = useState(0);
+
   const { isCouponLoading, couponDetails } = useAppSelector(selectOrder);
   const {
     offerV2: { giftable = false }
@@ -46,6 +48,15 @@ const Offer = ({
   useEffect(() => {
     setCoupon(couponCode);
   }, [couponCode]);
+
+  useEffect(() => {
+    // reload Payment component if it was loaded from bfcache
+    window.addEventListener('pageshow', (event) => {
+      if (event.persisted) {
+        setPaymentKey(Date.now());
+      }
+    });
+  }, []);
 
   if (isFree) {
     return (
@@ -89,7 +100,7 @@ const Offer = ({
           />
         </StyledOfferBody>
         {giftable && <DeliveryDetails giftable={giftable} />}
-        <Payment onPaymentComplete={onPaymentComplete} />
+        <Payment key={paymentKey} onPaymentComplete={onPaymentComplete} />
       </main>
       <Footer />
     </StyledOfferWrapper>


### PR DESCRIPTION
### Description

PayPal payment option becomes unclickable after returning from the PayPal page or stopping the PayPal redirection from loading

### Updates

Added page refresh if page was loaded from `bfcache`


