### PR TITLE
fix/MSSDK-1961: Fix the export path of the MSSDK font CSS; update readme about the proper way of importing the fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -754,7 +754,13 @@ import { Provider } from 'react-redux';
 
 #### Font
 
-If your application doesn't have a font specified, you can apply the default font (OpenSans) for all MSSDK components by:
+If your application doesn't have a font specified, you can apply the default font (OpenSans) for all MSSDK components by adding the following import to your application:
+
+```javascript
+import '@cleeng/mediastore-sdk/styles/msdFont.css';
+```
+
+For backwards compatibility, you can still import the font by adding the import below, but we encourage you to use the above syntax as the below is deprecated and will be removed in future releases.
 
 ```javascript
 import '@cleeng/mediastore-sdk/dist/styles/msdFont.css';

--- a/README.md
+++ b/README.md
@@ -754,13 +754,7 @@ import { Provider } from 'react-redux';
 
 #### Font
 
-If your application doesn't have a font specified, you can apply the default font (OpenSans) for all MSSDK components by adding the following import to your application:
-
-```javascript
-import '@cleeng/mediastore-sdk/styles/msdFont.css';
-```
-
-For backwards compatibility, you can still import the font by adding the import below, but we encourage you to use the above syntax as the one below is deprecated and will be removed in future releases.
+If your application doesn't have a font specified, you can apply the default font (OpenSans) for all MSSDK components by:
 
 ```javascript
 import '@cleeng/mediastore-sdk/dist/styles/msdFont.css';

--- a/README.md
+++ b/README.md
@@ -760,7 +760,7 @@ If your application doesn't have a font specified, you can apply the default fon
 import '@cleeng/mediastore-sdk/styles/msdFont.css';
 ```
 
-For backwards compatibility, you can still import the font by adding the import below, but we encourage you to use the above syntax as the below is deprecated and will be removed in future releases.
+For backwards compatibility, you can still import the font by adding the import below, but we encourage you to use the above syntax as the one below is deprecated and will be removed in future releases.
 
 ```javascript
 import '@cleeng/mediastore-sdk/dist/styles/msdFont.css';

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
       "require": "./dist/cleeng-mediastore-sdk.umd.cjs"
     },
     "./styles/msdFont.css": {
-      "default": "./dist/styles/msdFont.css"
+      "default": "./dist/styles/msdFont.css",
+      "import": "./dist/styles/msdFont.css"
     },
     "./dist/styles/msdFont.css": {
-      "default": "./dist/styles/msdFont.css"
+      "default": "./dist/styles/msdFont.css",
+      "import": "./dist/styles/msdFont.css"
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
       "import": "./dist/cleeng-mediastore-sdk.js",
       "require": "./dist/cleeng-mediastore-sdk.umd.cjs"
     },
-    "./styles/msdFont.css": {
-      "import": "./dist/styles/msdFont.css"
-    },
     "./dist/styles/msdFont.css": {
       "import": "./dist/styles/msdFont.css"
     }

--- a/package.json
+++ b/package.json
@@ -10,8 +10,12 @@
       "import": "./dist/cleeng-mediastore-sdk.js",
       "require": "./dist/cleeng-mediastore-sdk.umd.cjs"
     },
-    "./styles/msdFont.css": "./dist/styles/msdFont.css",
-    "./dist/styles/msdFont.css": "./dist/styles/msdFont.css"
+    "./styles/msdFont.css": {
+      "default": "./dist/styles/msdFont.css"
+    },
+    "./dist/styles/msdFont.css": {
+      "default": "./dist/styles/msdFont.css"
+    }
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     ".": {
       "import": "./dist/cleeng-mediastore-sdk.js",
       "require": "./dist/cleeng-mediastore-sdk.umd.cjs"
-    }
+    },
+    "./styles/msdFont.css": "./dist/styles/msdFont.css",
+    "./dist/styles/msdFont.css": "./dist/styles/msdFont.css"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -11,11 +11,9 @@
       "require": "./dist/cleeng-mediastore-sdk.umd.cjs"
     },
     "./styles/msdFont.css": {
-      "default": "./dist/styles/msdFont.css",
       "import": "./dist/styles/msdFont.css"
     },
     "./dist/styles/msdFont.css": {
-      "default": "./dist/styles/msdFont.css",
       "import": "./dist/styles/msdFont.css"
     }
   },

--- a/src/styles/msdFont.css
+++ b/src/styles/msdFont.css
@@ -3,16 +3,14 @@
   font-style: 'normal';
   font-weight: 300;
   font-display: swap;
-  src:
-    url('./../assets/fonts/OpenSans/OpenSans-Light.ttf') format('truetype'),
+  src: url('./../assets/fonts/OpenSans/OpenSans-Light.ttf') format('truetype');
 }
 @font-face {
   font-family: 'Open Sans';
   font-style: 'normal';
   font-weight: 400;
   font-display: swap;
-  src:
-    url('./../assets/fonts/OpenSans/OpenSans-Regular.ttf') format('truetype'),
+  src: url('./../assets/fonts/OpenSans/OpenSans-Regular.ttf') format('truetype');
 }
 
 @font-face {
@@ -20,8 +18,8 @@
   font-style: 'normal';
   font-weight: 600;
   font-display: swap;
-  src:
-    url('./../assets/fonts/OpenSans/OpenSans-SemiBold.ttf') format('truetype'),
+  src: url('./../assets/fonts/OpenSans/OpenSans-SemiBold.ttf')
+    format('truetype');
 }
 
 @font-face {
@@ -29,8 +27,7 @@
   font-style: 'normal';
   font-weight: 700;
   font-display: swap;
-  src:
-    url('./../assets/fonts/OpenSans/OpenSans-Bold.ttf') format('truetype'),
+  src: url('./../assets/fonts/OpenSans/OpenSans-Bold.ttf') format('truetype');
 }
 
 @font-face {
@@ -38,10 +35,11 @@
   font-style: 'normal';
   font-weight: 800;
   font-display: swap;
-  src:
-    url('./../assets/fonts/OpenSans/OpenSans-ExtraBold.ttf') format('truetype'),
+  src: url('./../assets/fonts/OpenSans/OpenSans-ExtraBold.ttf')
+    format('truetype');
 }
 
-* [class^='msd'], * [class*=' msd'] {
+* [class^='msd'],
+* [class*=' msd'] {
   font-family: 'Open Sans', sans-serif;
 }


### PR DESCRIPTION
### Description

Fix the export path of the MSSDK font CSS
Update readme about the proper way of importing the fonts