### PR TITLE
feat/MSSDK-2029: Align tax copy in checkout

### DIFF
--- a/src/components/CheckoutPriceBox/CheckoutPriceBox.tsx
+++ b/src/components/CheckoutPriceBox/CheckoutPriceBox.tsx
@@ -51,7 +51,6 @@ const CheckoutPriceBox = ({
       periods: discountedPeriods
     },
     taxRate,
-    country,
     totalPrice: finalPrice,
     currency,
     id: orderId
@@ -130,9 +129,7 @@ const CheckoutPriceBox = ({
         )}
         <StyledPriceWrapper>
           <StyledLabel id='taxValueLabel'>
-            {country === 'US'
-              ? t('checkout-price-box.applicable-tax', 'Applicable Tax')
-              : t('checkout-price-box.applicable-vat', 'Applicable VAT')}
+            {t('checkout-price-box.applicable-tax', 'Applicable Tax')}
           </StyledLabel>
           <StyledOfferPrice id='taxValue'>
             {!taxValue && isCouponApplied ? (

--- a/src/components/OfferCheckoutCard/OfferCheckoutCard.tsx
+++ b/src/components/OfferCheckoutCard/OfferCheckoutCard.tsx
@@ -48,7 +48,6 @@ const OfferCheckoutCard = ({
   const {
     priceBreakdown: { offerPrice },
     taxRate,
-    country,
     currency,
     totalPrice,
     discount: {
@@ -69,7 +68,7 @@ const OfferCheckoutCard = ({
 
   const { t } = useTranslation();
 
-  const taxCopy = country === 'US' ? 'Tax' : 'VAT';
+  const taxCopy = 'Tax';
 
   const periodValue =
     offerType === 'S' && period !== 'season'

--- a/src/translations/en/translations.json
+++ b/src/translations/en/translations.json
@@ -62,7 +62,6 @@
   "checkout-consents.subtitle": "Please accept Terms & Conditions",
   "checkout-consents.title": "Terms & Conditions",
   "checkout-price-box.applicable-tax": "Applicable Tax",
-  "checkout-price-box.applicable-vat": "Applicable VAT",
   "checkout-price-box.button.redeem": "Redeem here",
   "checkout-price-box.coupon-discount": "Coupon Discount",
   "checkout-price-box.coupon-note-applied": "Promotional Pricing applied!",


### PR DESCRIPTION
### Description

After some review from the finance team there was a decision to make one copy for the taxes in checkout 

### Updates

For the applied tax on the checkout, the term “Applicable tax” should be used universally. 

### Screenshots

### Testing

### Additional Notes
