### PR TITLE
fix/MSSDK-2117: MyAccount component throws error when saving personal info without editing the e-mail field

### DIFF
--- a/src/components/ProfileDetails/ProfileDetails.jsx
+++ b/src/components/ProfileDetails/ProfileDetails.jsx
@@ -168,7 +168,7 @@ class ProfileDetails extends Component {
     updateCustomer({
       firstName: updated.firstName,
       lastName: updated.lastName,
-      email: updated.email !== email ? updated.email : '',
+      ...(updated.email !== email && { email: updated.email }),
       confirmationPassword:
         updated.email !== email ? updated.confirmationPassword : ''
     }).then((response) => {


### PR DESCRIPTION
### Description

The email address remained unchanged, but the email validation in ProfileDetails throws an error.

### Updates

`email` field is now not included in request body when it's not updated


