### PR TITLE
feat/MSSDK-2126: Create Primer component without backend integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@adyen/adyen-web": "~5.66.1",
+    "@primer-io/checkout-web": "^2.49.2",
     "@reduxjs/toolkit": "^2.2.5",
     "camelcase": "^5.3.1",
     "classnames": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
     "react-redux": "^8.1.3",
     "react-select": "^5.5.4",
     "redux-thunk": "^2.4.2",
-    "resolve": "1.22.0",
-    "vite-plugin-webpackchunkname": "^1.0.3"
+    "resolve": "1.22.0"
   },
   "scripts": {
     "test": "vitest --silent",
@@ -151,7 +150,8 @@
     "typescript": "^4.9.5",
     "typescript-coverage-report": "^0.7.0",
     "vite": "^5.4.8",
+    "vitest": "^3.0.2",
     "vite-plugin-svgr": "^4.2.0",
-    "vitest": "^3.0.2"
+    "vite-plugin-webpackchunkname": "^1.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "react-redux": "^8.1.3",
     "react-select": "^5.5.4",
     "redux-thunk": "^2.4.2",
-    "resolve": "1.22.0"
+    "resolve": "1.22.0",
+    "vite-plugin-webpackchunkname": "^1.0.3"
   },
   "scripts": {
     "test": "vitest --silent",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -396,8 +396,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/runtime-corejs3@7.25.6':
-    resolution: {integrity: sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==}
+  '@babel/runtime-corejs3@7.26.7':
+    resolution: {integrity: sha512-55gRV8vGrCIYZnaQHQrD92Lo/hYE3Sj5tmbuf0hhHR7sj2CWhEhHU89hbq+UVDXvFG1zUVXJhUkEq1eAfqXtFw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.25.6':
@@ -1665,8 +1665,8 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  core-js-pure@3.38.1:
-    resolution: {integrity: sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==}
+  core-js-pure@3.40.0:
+    resolution: {integrity: sha512-AtDzVIgRrmRKQai62yuSIN5vNiQjcJakJb4fbhVw3ehxx7Lohphvw9SGNWKhLFqSxC4ilD0g/L1huAYFQU3Q6A==}
 
   core-js@3.40.0:
     resolution: {integrity: sha512-7vsMc/Lty6AGnn7uFpYT56QesI5D2Y/UkgKounk87OP9Z2H9Z8kj6jzcSGAxFmUtDOS0ntK6lbQz+Nsa0Jj6mQ==}
@@ -4283,11 +4283,11 @@ snapshots:
   '@adyen/adyen-web@5.66.1':
     dependencies:
       '@babel/runtime': 7.25.6
-      '@babel/runtime-corejs3': 7.25.6
+      '@babel/runtime-corejs3': 7.26.7
       '@types/applepayjs': 14.0.6
       '@types/googlepay': 0.7.6
       classnames: 2.5.1
-      core-js-pure: 3.38.1
+      core-js-pure: 3.40.0
       preact: 10.13.2
 
   '@ampproject/remapping@2.3.0':
@@ -4478,9 +4478,9 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/runtime-corejs3@7.25.6':
+  '@babel/runtime-corejs3@7.26.7':
     dependencies:
-      core-js-pure: 3.38.1
+      core-js-pure: 3.40.0
       regenerator-runtime: 0.14.1
 
   '@babel/runtime@7.25.6':
@@ -5869,7 +5869,7 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  core-js-pure@3.38.1: {}
+  core-js-pure@3.40.0: {}
 
   core-js@3.40.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@adyen/adyen-web':
         specifier: ~5.66.1
         version: 5.66.1
+      '@primer-io/checkout-web':
+        specifier: ^2.49.2
+        version: 2.49.2
       '@reduxjs/toolkit':
         specifier: ^2.2.5
         version: 2.2.7(react-redux@8.1.3(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(react@18.3.1)
@@ -766,6 +769,9 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@primer-io/checkout-web@2.49.2':
+    resolution: {integrity: sha512-wIRp6yKvZVk+wfEuXLKvfbaCpXbh6rCDP02p7kjoJ8E7Plxl97WQ6Y1b9A59SzdARczfpUzXYMZu6OvolG5cXg==}
 
   '@reduxjs/toolkit@2.2.7':
     resolution: {integrity: sha512-faI3cZbSdFb8yv9dhDTmGwclW0vk0z5o1cia+kf7gCbaCwHI5e+7tP57mJUv22pNcNbeA62GSrPpfrUfdXcQ6g==}
@@ -4905,6 +4911,8 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@primer-io/checkout-web@2.49.2': {}
 
   '@reduxjs/toolkit@2.2.7(react-redux@8.1.3(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(react@18.3.1)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,9 +77,6 @@ importers:
       resolve:
         specifier: 1.22.0
         version: 1.22.0
-      vite-plugin-webpackchunkname:
-        specifier: ^1.0.3
-        version: 1.0.3(rollup@4.23.0)
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.1.5
@@ -219,6 +216,9 @@ importers:
       vite-plugin-svgr:
         specifier: ^4.2.0
         version: 4.2.0(rollup@4.23.0)(typescript@4.9.5)(vite@5.4.8(@types/node@20.16.10))
+      vite-plugin-webpackchunkname:
+        specifier: ^1.0.3
+        version: 1.0.3(rollup@4.23.0)
       vitest:
         specifier: ^3.0.2
         version: 3.0.2(@types/node@20.16.10)(jsdom@24.1.3)
@@ -1668,8 +1668,8 @@ packages:
   core-js-pure@3.38.1:
     resolution: {integrity: sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==}
 
-  core-js@3.38.1:
-    resolution: {integrity: sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw==}
+  core-js@3.40.0:
+    resolution: {integrity: sha512-7vsMc/Lty6AGnn7uFpYT56QesI5D2Y/UkgKounk87OP9Z2H9Z8kj6jzcSGAxFmUtDOS0ntK6lbQz+Nsa0Jj6mQ==}
 
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
@@ -5871,7 +5871,7 @@ snapshots:
 
   core-js-pure@3.38.1: {}
 
-  core-js@3.38.1: {}
+  core-js@3.40.0: {}
 
   cosmiconfig@7.1.0:
     dependencies:
@@ -7910,7 +7910,7 @@ snapshots:
 
   react-app-polyfill@1.0.6:
     dependencies:
-      core-js: 3.38.1
+      core-js: 3.40.0
       object-assign: 4.1.1
       promise: 8.3.0
       raf: 3.4.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       resolve:
         specifier: 1.22.0
         version: 1.22.0
+      vite-plugin-webpackchunkname:
+        specifier: ^1.0.3
+        version: 1.0.3(rollup@4.23.0)
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.1.5
@@ -782,6 +785,15 @@ packages:
       react:
         optional: true
       react-redux:
+        optional: true
+
+  '@rollup/plugin-alias@5.1.1':
+    resolution: {integrity: sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
         optional: true
 
   '@rollup/pluginutils@5.1.2':
@@ -4040,6 +4052,9 @@ packages:
     peerDependencies:
       vite: ^2.6.0 || 3 || 4 || 5
 
+  vite-plugin-webpackchunkname@1.0.3:
+    resolution: {integrity: sha512-88lt6IrgCumnf4Up8eyaSJbmo4V0ZIaR4M94fbZvGGmK2aWMmPGVsiFBszYE7Kq04I9tGjLFnyremn+KEgEGyw==}
+
   vite@5.4.8:
     resolution: {integrity: sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -4923,6 +4938,10 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
       react-redux: 8.1.3(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)
+
+  '@rollup/plugin-alias@5.1.1(rollup@4.23.0)':
+    optionalDependencies:
+      rollup: 4.23.0
 
   '@rollup/pluginutils@5.1.2(rollup@4.23.0)':
     dependencies:
@@ -8734,6 +8753,15 @@ snapshots:
       - rollup
       - supports-color
       - typescript
+
+  vite-plugin-webpackchunkname@1.0.3(rollup@4.23.0):
+    dependencies:
+      '@rollup/plugin-alias': 5.1.1(rollup@4.23.0)
+      '@rollup/pluginutils': 5.1.2(rollup@4.23.0)
+      es-module-lexer: 1.6.0
+      magic-string: 0.30.17
+    transitivePeerDependencies:
+      - rollup
 
   vite@5.4.8(@types/node@20.16.10):
     dependencies:

--- a/src/appRedux/types/publisherConfigSlice.types.ts
+++ b/src/appRedux/types/publisherConfigSlice.types.ts
@@ -39,7 +39,7 @@ export type PaymentMethodName =
   | 'free-offer'
   | 'gcash';
 
-export type PaymentGateway = 'adyen' | 'paypal' | 'free-offer';
+export type PaymentGateway = 'adyen' | 'primer' | 'paypal' | 'free-offer';
 
 export type PublisherConfigInitialState = {
   publisherId: string;

--- a/src/components/Adyen/Adyen.jsx
+++ b/src/components/Adyen/Adyen.jsx
@@ -495,7 +495,10 @@ const Adyen = ({
   }
 
   return (
-    <AdyenStyled $isMyAccount $isAdditionalPayment={isPayPalAvailable}>
+    <AdyenStyled
+      $isMyAccount={isMyAccount}
+      $isAdditionalPayment={isPayPalAvailable}
+    >
       {isLoading && <Loader />}
       <div ref={paymentMethodsRef} />
     </AdyenStyled>

--- a/src/components/Payment/Payment.tsx
+++ b/src/components/Payment/Payment.tsx
@@ -39,8 +39,12 @@ import PayPal from './PayPal/PayPal';
 import DropInSection from './DropInSection/DropInSection';
 import { PaymentProps } from './Payment.types';
 
-const Adyen = lazy(() => import('components/Adyen'));
-const Primer = lazy(() => import('components/Primer'));
+const Adyen = lazy(
+  () => import(/* webpackChunkName: "adyen-component" */ 'components/Adyen')
+);
+const Primer = lazy(
+  () => import(/* webpackChunkName: "primer-component" */ 'components/Primer')
+);
 
 const Payment = ({ onPaymentComplete }: PaymentProps) => {
   const { paymentMethods: publisherPaymentMethods, isPayPalHidden } =

--- a/src/components/Payment/Payment.tsx
+++ b/src/components/Payment/Payment.tsx
@@ -57,7 +57,7 @@ const Payment = ({ onPaymentComplete }: PaymentProps) => {
 
   const [generalError, setGeneralError] = useState<string>('');
 
-  const [dropInInstance, setDropInInstance] = useState<unknown | null>(null);
+  const [dropInInstance, setDropInInstance] = useState<unknown>(null);
 
   const [isActionHandlingProcessing, setIsActionHandlingProcessing] =
     useState(false);

--- a/src/components/Payment/Payment.tsx
+++ b/src/components/Payment/Payment.tsx
@@ -57,6 +57,8 @@ const Payment = ({ onPaymentComplete }: PaymentProps) => {
 
   const [generalError, setGeneralError] = useState<string>('');
 
+  // add correct type during adyen-web v6 migration
+  // https://cleeng.atlassian.net/browse/MSSDK-2139
   const [dropInInstance, setDropInInstance] = useState<unknown>(null);
 
   const [isActionHandlingProcessing, setIsActionHandlingProcessing] =
@@ -294,8 +296,8 @@ const Payment = ({ onPaymentComplete }: PaymentProps) => {
   };
 
   // add correct type during adyen-web v6 migration
+  // https://cleeng.atlassian.net/browse/MSSDK-2139
   const getDropIn = (drop: unknown) => {
-    // TODO check if paymentMethodType is correct
     setDropInInstance(drop);
   };
 
@@ -329,20 +331,14 @@ const Payment = ({ onPaymentComplete }: PaymentProps) => {
     ? false
     : shouldShowGatewayComponent('paypal', publisherPaymentMethods);
 
-  const adyenProps = {
-    onSubmit: onAdyenSubmit,
-    selectPaymentMethod: selectPaymentMethodHandler,
-    isPayPalAvailable: shouldShowPayPal,
-    getDropIn,
-    onAdditionalDetails
-  };
-
   const noPaymentMethods = !publisherPaymentMethods.length;
 
-  const showPayPalWhenAdyenIsReady = () =>
-    shouldShowGatewayComponent('adyen', publisherPaymentMethods)
-      ? !!dropInInstance
-      : true;
+  const showPayPalWhenAdyenIsReady = shouldShowGatewayComponent(
+    'adyen',
+    publisherPaymentMethods
+  )
+    ? !!dropInInstance
+    : true;
 
   if (noPaymentMethods && !isLoading) {
     return (
@@ -394,9 +390,17 @@ const Payment = ({ onPaymentComplete }: PaymentProps) => {
       </SectionHeader>
       <PaymentWrapperStyled>
         {isPaymentFinalizationInProgress && <Loader />}
-        <PaymentDropIn adyenProps={adyenProps} />
+        <PaymentDropIn
+          adyenProps={{
+            onSubmit: onAdyenSubmit,
+            selectPaymentMethod: selectPaymentMethodHandler,
+            isPayPalAvailable: shouldShowPayPal,
+            getDropIn,
+            onAdditionalDetails
+          }}
+        />
         {shouldShowPayPal &&
-          showPayPalWhenAdyenIsReady() &&
+          showPayPalWhenAdyenIsReady &&
           !isActionHandlingProcessing && (
             <DropInSection
               selectPaymentMethod={selectPaymentMethodHandler}

--- a/src/components/Payment/Payment.tsx
+++ b/src/components/Payment/Payment.tsx
@@ -1,9 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, lazy } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getPaymentMethods, submitPayment, submitPayPalPayment } from 'api';
 import { submitPaymentWithoutDetails } from 'appRedux/paymentSlice';
 import Button from 'components/Button';
-import Adyen from 'components/Adyen';
 import Loader from 'components/Loader';
 import SectionHeader from 'components/SectionHeader';
 import { validateDeliveryDetailsForm } from 'components/DeliveryDetails/RecipientForm/validators';
@@ -39,6 +38,9 @@ import eventDispatcher, {
 import PayPal from './PayPal/PayPal';
 import DropInSection from './DropInSection/DropInSection';
 import { PaymentProps } from './Payment.types';
+
+const Adyen = lazy(() => import('components/Adyen'));
+const Primer = lazy(() => import('components/Primer'));
 
 const Payment = ({ onPaymentComplete }: PaymentProps) => {
   const { paymentMethods: publisherPaymentMethods, isPayPalHidden } =
@@ -394,6 +396,7 @@ const Payment = ({ onPaymentComplete }: PaymentProps) => {
       </SectionHeader>
       <PaymentWrapperStyled>
         {isPaymentFinalizationInProgress && <Loader />}
+        <Primer />
         {shouldShowAdyen && (
           <Adyen
             key={adyenKey}

--- a/src/components/PaymentDropIn/PaymentDropIn.tsx
+++ b/src/components/PaymentDropIn/PaymentDropIn.tsx
@@ -1,0 +1,36 @@
+import { lazy, Suspense } from 'react';
+import { selectPublisherConfig } from 'appRedux/publisherConfigSlice';
+import { useAppSelector } from 'appRedux/store';
+import { shouldShowGatewayComponent } from 'util/paymentMethodHelper';
+import Loader from 'components/Loader';
+
+import { PaymentDropInProps } from './PaymentDropIn.types';
+
+const Adyen = lazy(
+  () => import(/* webpackChunkName: "adyen-component" */ 'components/Adyen')
+);
+const Primer = lazy(
+  () => import(/* webpackChunkName: "primer-component" */ 'components/Primer')
+);
+
+const PaymentDropIn = ({ adyenProps }: PaymentDropInProps) => {
+  const { paymentMethods: publisherPaymentMethods } = useAppSelector(
+    selectPublisherConfig
+  );
+
+  const getPaymentDropIn = () => {
+    if (shouldShowGatewayComponent('primer', publisherPaymentMethods)) {
+      return <Primer />;
+    }
+
+    if (shouldShowGatewayComponent('adyen', publisherPaymentMethods)) {
+      return <Adyen {...adyenProps} />;
+    }
+
+    return null;
+  };
+
+  return <Suspense fallback={<Loader />}>{getPaymentDropIn()}</Suspense>;
+};
+
+export default PaymentDropIn;

--- a/src/components/PaymentDropIn/PaymentDropIn.tsx
+++ b/src/components/PaymentDropIn/PaymentDropIn.tsx
@@ -7,7 +7,17 @@ import { PaymentDropInProps } from './PaymentDropIn.types';
 const PaymentDropIn = ({ adyenProps }: PaymentDropInProps) => {
   const dropInComponent = usePaymentDropIn(adyenProps);
 
-  return <Suspense fallback={<Loader />}>{dropInComponent}</Suspense>;
+  if (!dropInComponent) {
+    return null;
+  }
+
+  const { Component, props } = dropInComponent;
+
+  return (
+    <Suspense fallback={<Loader />}>
+      <Component {...props} />
+    </Suspense>
+  );
 };
 
 export default PaymentDropIn;

--- a/src/components/PaymentDropIn/PaymentDropIn.tsx
+++ b/src/components/PaymentDropIn/PaymentDropIn.tsx
@@ -1,36 +1,13 @@
-import { lazy, Suspense } from 'react';
-import { selectPublisherConfig } from 'appRedux/publisherConfigSlice';
-import { useAppSelector } from 'appRedux/store';
-import { shouldShowGatewayComponent } from 'util/paymentMethodHelper';
+import { Suspense } from 'react';
 import Loader from 'components/Loader';
+import usePaymentDropIn from 'hooks/usePaymentDropIn';
 
 import { PaymentDropInProps } from './PaymentDropIn.types';
 
-const Adyen = lazy(
-  () => import(/* webpackChunkName: "adyen-component" */ 'components/Adyen')
-);
-const Primer = lazy(
-  () => import(/* webpackChunkName: "primer-component" */ 'components/Primer')
-);
-
 const PaymentDropIn = ({ adyenProps }: PaymentDropInProps) => {
-  const { paymentMethods: publisherPaymentMethods } = useAppSelector(
-    selectPublisherConfig
-  );
+  const dropInComponent = usePaymentDropIn(adyenProps);
 
-  const getPaymentDropIn = () => {
-    if (shouldShowGatewayComponent('primer', publisherPaymentMethods)) {
-      return <Primer />;
-    }
-
-    if (shouldShowGatewayComponent('adyen', publisherPaymentMethods)) {
-      return <Adyen {...adyenProps} />;
-    }
-
-    return null;
-  };
-
-  return <Suspense fallback={<Loader />}>{getPaymentDropIn()}</Suspense>;
+  return <Suspense fallback={<Loader />}>{dropInComponent}</Suspense>;
 };
 
 export default PaymentDropIn;

--- a/src/components/PaymentDropIn/PaymentDropIn.types.ts
+++ b/src/components/PaymentDropIn/PaymentDropIn.types.ts
@@ -1,0 +1,13 @@
+// Add correct types from adyen-web package during migration to adyen-web v6 and Adyen component to TypeScript
+type AdyenProps = {
+  isPayPalAvailable: boolean;
+  isMyAccount?: boolean;
+  onSubmit: unknown; // get type from adyen-web v6
+  onAdditionalDetails: unknown; // get type from adyen-web v6
+  selectPaymentMethod: (paymentMethod: string) => void;
+  getDropIn: (drop: unknown) => void; // get type from adyen-web v6
+};
+
+export type PaymentDropInProps = {
+  adyenProps: AdyenProps;
+};

--- a/src/components/PaymentDropIn/PaymentDropIn.types.ts
+++ b/src/components/PaymentDropIn/PaymentDropIn.types.ts
@@ -1,12 +1,4 @@
-// Add correct types from adyen-web package during migration to adyen-web v6 and Adyen component to TypeScript
-type AdyenProps = {
-  isPayPalAvailable: boolean;
-  isMyAccount?: boolean;
-  onSubmit: unknown; // get type from adyen-web v6
-  onAdditionalDetails: unknown; // get type from adyen-web v6
-  selectPaymentMethod: (paymentMethod: string) => void;
-  getDropIn: (drop: unknown) => void; // get type from adyen-web v6
-};
+import { AdyenProps } from 'types/Adyen.types';
 
 export type PaymentDropInProps = {
   adyenProps: AdyenProps;

--- a/src/components/PaymentDropIn/index.ts
+++ b/src/components/PaymentDropIn/index.ts
@@ -1,0 +1,3 @@
+import PaymentDropIn from './PaymentDropIn';
+
+export default PaymentDropIn;

--- a/src/components/Primer/Primer.tsx
+++ b/src/components/Primer/Primer.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import { Primer as PrimerSDK } from '@primer-io/checkout-web';
+
+const clientToken = 'abc';
+
+const options = {
+  container: '#msd__primerWrapper'
+};
+
+const Primer = () => {
+  const createDropIn = async () => {
+    await PrimerSDK.showUniversalCheckout(clientToken, options);
+  };
+
+  useEffect(() => {
+    createDropIn();
+  }, []);
+
+  return <div id='msd__primerWrapper' />;
+};
+
+export default Primer;

--- a/src/components/Primer/Primer.tsx
+++ b/src/components/Primer/Primer.tsx
@@ -1,16 +1,18 @@
 import { useEffect } from 'react';
 import { Primer as PrimerSDK } from '@primer-io/checkout-web';
 
-const clientToken = 'abc';
+// Client token will be fetched from the server
+const CLIENT_TOKEN = 'abc';
+const CONTAINER = '#msd__primerWrapper';
 
 const options = {
-  container: '#msd__primerWrapper'
+  container: CONTAINER
 };
 
 const Primer = () => {
   useEffect(() => {
     const createDropIn = async () => {
-      await PrimerSDK.showUniversalCheckout(clientToken, options);
+      await PrimerSDK.showUniversalCheckout(CLIENT_TOKEN, options);
     };
     createDropIn();
   }, []);

--- a/src/components/Primer/Primer.tsx
+++ b/src/components/Primer/Primer.tsx
@@ -3,10 +3,10 @@ import { Primer as PrimerSDK } from '@primer-io/checkout-web';
 
 // Client token will be fetched from the server
 const CLIENT_TOKEN = 'abc';
-const CONTAINER = '#msd__primerWrapper';
+const CONTAINER = 'msd__primerWrapper';
 
 const options = {
-  container: CONTAINER
+  container: `#${CONTAINER}`
 };
 
 const Primer = () => {
@@ -17,7 +17,7 @@ const Primer = () => {
     createDropIn();
   }, []);
 
-  return <div id='msd__primerWrapper' />;
+  return <div id={CONTAINER} />;
 };
 
 export default Primer;

--- a/src/components/Primer/Primer.tsx
+++ b/src/components/Primer/Primer.tsx
@@ -8,11 +8,10 @@ const options = {
 };
 
 const Primer = () => {
-  const createDropIn = async () => {
-    await PrimerSDK.showUniversalCheckout(clientToken, options);
-  };
-
   useEffect(() => {
+    const createDropIn = async () => {
+      await PrimerSDK.showUniversalCheckout(clientToken, options);
+    };
     createDropIn();
   }, []);
 

--- a/src/components/Primer/index.ts
+++ b/src/components/Primer/index.ts
@@ -1,0 +1,3 @@
+import Primer from './Primer';
+
+export default Primer;

--- a/src/components/UpdatePaymentDetailsPopup/UpdatePaymentDetailsPopup.jsx
+++ b/src/components/UpdatePaymentDetailsPopup/UpdatePaymentDetailsPopup.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, lazy, Suspense } from 'react';
+import { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import InnerPopupWrapper from 'components/InnerPopupWrapper';
@@ -11,6 +11,7 @@ import {
   ButtonWrapperStyled,
   WarningMessageStyled
 } from 'components/InnerPopupWrapper/InnerPopupWrapperStyled';
+import PaymentDropIn from 'components/PaymentDropIn';
 import { fetchFinalizeAddPaymentDetails } from 'appRedux/finalizeAddPaymentDetailsSlice';
 import {
   updatePaymentDetailsPopup,
@@ -50,13 +51,6 @@ import {
 } from './Steps';
 import PayPal from '../Payment/PayPal/PayPal';
 import Loader from '../Loader';
-
-const Adyen = lazy(() =>
-  import(/* webpackChunkName: "adyen-component" */ 'components/Adyen')
-);
-const Primer = lazy(() =>
-  import(/* webpackChunkName: "primer-component" */ 'components/Primer')
-);
 
 const PaymentMethodIcons = {
   amazon: AmazonIcon,
@@ -269,30 +263,17 @@ const UpdatePaymentDetailsPopup = () => {
     : shouldShowGatewayComponent('paypal', paymentMethods);
 
   const shouldShowAdyen = shouldShowGatewayComponent('adyen', paymentMethods);
-  const shouldShowPrimer = shouldShowGatewayComponent('primer', paymentMethods);
 
   const showPayPalWhenAdyenIsReady = () =>
     shouldShowAdyen ? !!dropInInstance : true;
 
-  const getPaymentDropIn = () => {
-    if (shouldShowPrimer) {
-      return <Primer />;
-    }
-
-    if (shouldShowAdyen) {
-      return (
-        <Adyen
-          isMyAccount
-          onSubmit={addAdyenPaymentDetails}
-          selectPaymentMethod={selectPaymentMethodHandler}
-          isPayPalAvailable={shouldShowPayPal}
-          getDropIn={getDropIn}
-          onAdditionalDetails={onAdditionalDetails}
-        />
-      );
-    }
-
-    return null;
+  const adyenProps = {
+    isMyAccount: true,
+    onSubmit: addAdyenPaymentDetails,
+    selectPaymentMethod: selectPaymentMethodHandler,
+    isPayPalAvailable: shouldShowPayPal,
+    getDropIn,
+    onAdditionalDetails
   };
 
   if (step === PAYMENT_DETAILS_STEPS.DELETE_PAYMENT_DETAILS) {
@@ -402,7 +383,7 @@ const UpdatePaymentDetailsPopup = () => {
           )}
         </TextStyled>
         <PaymentMethodsWrapperStyled>
-          <Suspense fallback={<Loader />}>{getPaymentDropIn()}</Suspense>
+          <PaymentDropIn adyenProps={adyenProps} />
           {shouldShowPayPal &&
             showPayPalWhenAdyenIsReady() &&
             !isActionHandlingProcessing && (

--- a/src/hooks/usePaymentDropIn.ts
+++ b/src/hooks/usePaymentDropIn.ts
@@ -12,17 +12,24 @@ const Primer = lazy(
   () => import(/* webpackChunkName: "primer-component" */ 'components/Primer')
 );
 
-const usePaymentDropIn = (adyenProps: AdyenProps) => {
+type UsePaymentDropInReturnType = {
+  Component: typeof Adyen | typeof Primer;
+  props: AdyenProps | Record<string, unknown>;
+} | null;
+
+const usePaymentDropIn = (
+  adyenProps: AdyenProps
+): UsePaymentDropInReturnType => {
   const { paymentMethods: publisherPaymentMethods } = useAppSelector(
     selectPublisherConfig
   );
 
   if (shouldShowGatewayComponent('primer', publisherPaymentMethods)) {
-    return <Primer />;
+    return { Component: Primer, props: {} };
   }
 
   if (shouldShowGatewayComponent('adyen', publisherPaymentMethods)) {
-    return <Adyen {...adyenProps} />;
+    return { Component: Adyen, props: adyenProps };
   }
 
   return null;

--- a/src/hooks/usePaymentDropIn.tsx
+++ b/src/hooks/usePaymentDropIn.tsx
@@ -1,0 +1,31 @@
+import { lazy } from 'react';
+import { selectPublisherConfig } from 'appRedux/publisherConfigSlice';
+import { useAppSelector } from 'appRedux/store';
+import { shouldShowGatewayComponent } from 'util/paymentMethodHelper';
+
+import { AdyenProps } from 'types/Adyen.types';
+
+const Adyen = lazy(
+  () => import(/* webpackChunkName: "adyen-component" */ 'components/Adyen')
+);
+const Primer = lazy(
+  () => import(/* webpackChunkName: "primer-component" */ 'components/Primer')
+);
+
+const usePaymentDropIn = (adyenProps: AdyenProps) => {
+  const { paymentMethods: publisherPaymentMethods } = useAppSelector(
+    selectPublisherConfig
+  );
+
+  if (shouldShowGatewayComponent('primer', publisherPaymentMethods)) {
+    return <Primer />;
+  }
+
+  if (shouldShowGatewayComponent('adyen', publisherPaymentMethods)) {
+    return <Adyen {...adyenProps} />;
+  }
+
+  return null;
+};
+
+export default usePaymentDropIn;

--- a/src/types/Adyen.types.ts
+++ b/src/types/Adyen.types.ts
@@ -1,0 +1,10 @@
+// Add correct types from adyen-web package during migration to adyen-web v6 and Adyen component to TypeScript
+// https://cleeng.atlassian.net/browse/MSSDK-2139
+export type AdyenProps = {
+  isPayPalAvailable: boolean;
+  isMyAccount?: boolean;
+  onSubmit: unknown; // get type from adyen-web v6
+  onAdditionalDetails: unknown; // get type from adyen-web v6
+  selectPaymentMethod: (paymentMethod: string) => void;
+  getDropIn: (drop: unknown) => void; // get type from adyen-web v6
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,9 +3,10 @@ import { defineConfig } from 'vite';
 import path from 'node:path';
 import react from '@vitejs/plugin-react-swc';
 import svgr from 'vite-plugin-svgr';
+import { manualChunksPlugin } from 'vite-plugin-webpackchunkname';
 
 export default defineConfig({
-  plugins: [react(), svgr({ include: '**/*.svg' })],
+  plugins: [react(), svgr({ include: '**/*.svg' }), manualChunksPlugin()],
   build: {
     target: 'es2015',
     cssCodeSplit: true,
@@ -25,6 +26,17 @@ export default defineConfig({
           react: 'React',
           'react-redux': 'reactRedux',
           'styled-components': 'styled-components'
+        },
+        manualChunks(id: string) {
+          if (id.includes('@adyen/adyen-web')) {
+            return 'adyen-library';
+          }
+
+          if (id.includes('@primer-io/checkout-web')) {
+            return 'primer-library';
+          }
+
+          return null;
         }
       }
     }


### PR DESCRIPTION
### Description

To introduce a `Primer` component similar to the existing `Adyen` component in the project. Import it using lazy loading. The component will import and initialize `@primer-io/checkout-web` but will not be integrated with the backend, resulting in an expected error.

