### PR TITLE
fix: add captcha to free offer and coupon payment flows

### DIFF
--- a/src/api/Payment/submitPaymentWithoutDetails.js
+++ b/src/api/Payment/submitPaymentWithoutDetails.js
@@ -2,14 +2,14 @@ import { getData } from 'util/appConfigHelper';
 import fetchWithJWT from 'util/fetchHelper';
 import getApiURL from 'util/environmentHelper';
 
-const submitPaymentWithoutDetails = async () => {
+const submitPaymentWithoutDetails = async (captchaValue) => {
   const API_URL = getApiURL();
   const orderId = parseInt(getData('CLEENG_ORDER_ID') || '0', 10);
   const url = `${API_URL}/payments`;
 
   return fetchWithJWT(url, {
     method: 'POST',
-    body: JSON.stringify({ orderId })
+    body: JSON.stringify({ orderId, captchaValue })
   })
     .then(async (res) => {
       const { responseData, errors } = await res.json();

--- a/src/appRedux/paymentSlice.ts
+++ b/src/appRedux/paymentSlice.ts
@@ -42,19 +42,22 @@ const initialState: InitialState = {
 
 export const submitPaymentWithoutDetails = createAsyncThunk<
   Payment,
-  undefined,
+  string | undefined,
   {
     rejectValue: string;
   }
->('payment/submitPaymentWithoutDetails', async (_, { rejectWithValue }) => {
-  try {
-    const payment = await submitPaymentWithoutDetailsRequest();
-    return payment;
-  } catch (err) {
-    const typedError = err as Error;
-    return rejectWithValue(typedError.message);
+>(
+  'payment/submitPaymentWithoutDetails',
+  async (captchaValue, { rejectWithValue }) => {
+    try {
+      const payment = await submitPaymentWithoutDetailsRequest(captchaValue);
+      return payment;
+    } catch (err) {
+      const typedError = err as Error;
+      return rejectWithValue(typedError.message);
+    }
   }
-});
+);
 
 export const paymentSlice = createSlice({
   name: 'paymentSlice',

--- a/src/components/FreeOffer/FreeOffer.tsx
+++ b/src/components/FreeOffer/FreeOffer.tsx
@@ -6,7 +6,9 @@ import {
 import { useAppDispatch, useAppSelector } from 'appRedux/store';
 import Button from 'components/Button';
 import Loader from 'components/Loader';
-import { useCallback } from 'react';
+import useCaptchaVerification from 'hooks/useCaptchaVerification';
+import { useCallback, useState } from 'react';
+import ReCAPTCHA from 'react-google-recaptcha';
 import { useTranslation } from 'react-i18next';
 import { dateFormat, type Period, periodMapper } from 'util/planHelper';
 import type { FreeOfferProps } from './FreeOffer.types';
@@ -92,6 +94,9 @@ const FreeOffer = ({ onPaymentComplete }: FreeOfferProps) => {
   } = useAppSelector(selectOnlyOffer);
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
+  const { getCaptchaToken, recaptchaRef, showCaptchaOnPurchase, sitekey } =
+    useCaptchaVerification();
+  const [captchaError, setCaptchaError] = useState('');
 
   const offerType = offerId?.charAt(0);
   const icon = period || offerType;
@@ -103,9 +108,21 @@ const FreeOffer = ({ onPaymentComplete }: FreeOfferProps) => {
     t
   });
 
-  const getAccessToFreeOffer = useCallback(() => {
+  const getAccessToFreeOffer = useCallback(async () => {
+    if (showCaptchaOnPurchase) {
+      const { hasCaptchaSucceeded, captchaToken, recaptchaError } =
+        await getCaptchaToken();
+      if (!hasCaptchaSucceeded) {
+        setCaptchaError(recaptchaError);
+        return;
+      }
+      dispatch(submitPaymentWithoutDetails(captchaToken))
+        .unwrap()
+        .then(onPaymentComplete);
+      return;
+    }
     dispatch(submitPaymentWithoutDetails()).unwrap().then(onPaymentComplete);
-  }, []);
+  }, [showCaptchaOnPurchase, getCaptchaToken]);
 
   return (
     <WrapStyled>
@@ -138,7 +155,18 @@ const FreeOffer = ({ onPaymentComplete }: FreeOfferProps) => {
               {t(error.translationKey, error.message as string)}
             </ErrorMessageStyled>
           )}
+          {captchaError && (
+            <ErrorMessageStyled>{captchaError}</ErrorMessageStyled>
+          )}
         </ButtonWrapperStyled>
+        {showCaptchaOnPurchase && (
+          <ReCAPTCHA
+            ref={recaptchaRef}
+            size='invisible'
+            badge='bottomright'
+            sitekey={sitekey}
+          />
+        )}
         <SubTextStyled>
           {t('free-offer.no-cost', 'Free, no additional cost')}
         </SubTextStyled>

--- a/src/components/Payment/Payment.tsx
+++ b/src/components/Payment/Payment.tsx
@@ -358,7 +358,14 @@ const Payment = ({ onPaymentComplete }: PaymentProps) => {
     setIsLoading(true);
     setGeneralError('');
 
-    dispatch(submitPaymentWithoutDetails())
+    const { captchaToken, shouldProceed } = await handleCaptchaVerification();
+
+    if (!shouldProceed) {
+      setIsLoading(false);
+      return;
+    }
+
+    dispatch(submitPaymentWithoutDetails(captchaToken))
       .unwrap()
       .then((payment) => {
         eventDispatcher(MSSDK_PURCHASE_SUCCESSFUL, {
@@ -392,6 +399,15 @@ const Payment = ({ onPaymentComplete }: PaymentProps) => {
 
   const showPayPalWhenAdyenIsReady = () =>
     shouldShowAdyen ? !!dropInInstance : true;
+
+  const handleCaptchaChange = () => {
+    if (
+      generalError ===
+      t('validators.captcha-invalid', 'Google reCAPTCHA verification required.')
+    ) {
+      setGeneralError('');
+    }
+  };
 
   if (noPaymentMethods && !isLoading) {
     return (
@@ -432,18 +448,18 @@ const Payment = ({ onPaymentComplete }: PaymentProps) => {
             <>{t('payment.complete-purchase', 'Complete purchase')}</>
           )}
         </Button>
+        {showCaptchaOnPurchase && (
+          <ReCAPTCHA
+            ref={recaptchaRef}
+            size='invisible'
+            badge='bottomright'
+            sitekey={sitekey}
+            onChange={handleCaptchaChange}
+          />
+        )}
       </PaymentStyled>
     );
   }
-
-  const handleCaptchaChange = () => {
-    if (
-      generalError ===
-      t('validators.captcha-invalid', 'Google reCAPTCHA verification required.')
-    ) {
-      setGeneralError('');
-    }
-  };
 
   return (
     <PaymentStyled>


### PR DESCRIPTION
## Summary
When `showCaptchaOnPurchase` is enabled, two payment paths in the SDK skipped reCAPTCHA verification entirely — applying a 100% discount coupon and accessing a natively free offer. Both paths now obtain and send a captcha token before calling the payments API.

## JIRA Ticket
SXP-601

## Business Context
Publishers using reCAPTCHA enforcement reported that subscribers could not redeem 100% discount coupons — the coupon reduces the total to £0.00, which switches the UI to a "Complete purchase" flow that bypassed captcha. The backend enforces captcha and returns `CPT0001`, blocking the purchase. The same issue affects natively free offers. Escalation originated from Baby First TV (Zendesk ticket 1598949).

## Business Benefits
Publishers with reCAPTCHA configured (`showCaptchaOnPurchase: true`) can now process 100% coupon redemptions and free offer access without failures. Unblocks at least one active broadcaster from a customer-facing purchase error.

## Technical Design
The root cause was that `submitPaymentWithoutDetails` never obtained a captcha token, unlike the Adyen and PayPal paths. Fix applied at each layer: API function accepts optional `captchaValue`, Redux thunk forwards it, Payment component calls `handleCaptchaVerification()` before dispatch and renders ReCAPTCHA in the early-return branch, FreeOffer component adds the hook and async captcha check.

## Technical Impact
The `/payments` API endpoint now receives `captchaValue` in the request body for all three payment paths when captcha is configured. No breaking changes — `captchaValue` is optional and behaviour when `showCaptchaOnPurchase: false` is unchanged.

## Changes Overview
- reCAPTCHA verification added to the "Complete purchase" flow triggered by a 100% coupon discount
- reCAPTCHA verification added to the "Get Access" flow for natively free offers
- Invisible reCAPTCHA widget rendered in both affected UI branches when captcha is configured
- `submitPaymentWithoutDetails` API function and Redux thunk updated to accept and forward the captcha token

## Testing
Manually verified with `showCaptchaOnPurchase: true` and a 100% coupon — the `/payments` request payload now includes `captchaValue`. All 65 existing automated tests pass.