### PR TITLE
docs: add deprecation warning to mediastore-sdk README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # <div align="center"> MediaStore SDK</div>
 
-> **Warning**
+> **Note**
 >
-> Breaking changes in version 4.0. See the [imports](#1-import-the-required-css) section of this file for more information.
+> ⚠️ This is not the recommended integration method. Please use [**Hosted Customer Flows**](https://developers.cleeng.com/docs/implementing-hosted-customer-flows) instead.
 
 This is the Cleeng official component library to be used with React.js.
 


### PR DESCRIPTION
## Summary
Replaces the outdated v4 breaking changes warning in the README with a deprecation note directing users to Hosted Customer Flows, the recommended integration method.

## JIRA Ticket
SXP-716

## Business Context
Cleeng now recommends Hosted Customer Flows as the primary integration path. Users who find the `@cleeng/mediastore-sdk` package on npm or GitHub should be immediately informed that this component-based approach is not the preferred method and directed to the recommended alternative.

## Business Benefits
- Users landing on the npm page are redirected to the recommended integration, reducing investment in a non-preferred integration path.
- Removes the stale v4 breaking changes warning that no longer applies to current adopters.

## Technical Design
Single README.md change: the `> **Warning**` blockquote about v4 breaking changes is replaced with a `> **Note**` blockquote containing the deprecation message and a direct link to the Hosted Customer Flows documentation.

## Technical Impact
Documentation only — no code changes. The npm package page (`@cleeng/mediastore-sdk`) will reflect the updated note on next publish.

## Changes Overview
- Warning at the top of the README updated: removed v4 breaking changes notice, added a deprecation note pointing to Hosted Customer Flows.

## Testing
No automated tests required — documentation-only change. Markdown rendering verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)